### PR TITLE
fix: Various cleanup in the transcript

### DIFF
--- a/crates/rite-model/src/transcript.rs
+++ b/crates/rite-model/src/transcript.rs
@@ -35,20 +35,24 @@ pub struct CeremonyInfo {
     pub fingerprint: String,
     /// Ceremony name.
     pub name: String,
-    /// Ceremony version from the DSL.
-    pub version: String,
 }
 
-/// Information about resolved ceremony inputs (parameters, etc.).
+/// Information about resolved ceremony inputs (parameters, materials).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstanceInfo {
-    /// SHA-256 fingerprint of resolved parameter values.
+    /// SHA-256 fingerprint of all resolved runtime inputs (parameters + material fingerprints).
     pub fingerprint: String,
     /// Resolved parameters (names, dates, labels).
     ///
     /// Uses `BTreeMap` for deterministic serialization order in JSONL transcripts.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub parameters: BTreeMap<String, serde_json::Value>,
+    /// SHA-256 fingerprints of digital materials, keyed by material ID.
+    ///
+    /// Physical materials have no digital fingerprint and are omitted.
+    /// Uses `BTreeMap` for deterministic serialization order in JSONL transcripts.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub materials: BTreeMap<String, String>,
 }
 
 /// A participant assigned to a role for this ceremony execution.

--- a/crates/rite-runtime/src/executor.rs
+++ b/crates/rite-runtime/src/executor.rs
@@ -19,7 +19,7 @@ use rite_model::{
     OutputId, ParamId, RoleId, Step, StepId,
 };
 use rite_sdk::BackendError;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::io::{self, BufRead, Write};
 use std::path::PathBuf;
@@ -199,6 +199,7 @@ impl<R: BufRead + Send, W: Write + Send> CeremonyExecutor<R, W> {
         ceremony: &Ceremony,
         resolved_params: &HashMap<ParamId, serde_json::Value>,
         roles: &HashMap<RoleId, (String, Option<String>)>,
+        material_fingerprints: BTreeMap<String, String>,
     ) -> Result<(Box<dyn TranscriptWriter>, Option<PathBuf>), ExecutionError> {
         let transcript_path = self.transcript_config.path.clone();
         let mut writer: Box<dyn TranscriptWriter> = match &transcript_path {
@@ -223,8 +224,11 @@ impl<R: BufRead + Send, W: Write + Send> CeremonyExecutor<R, W> {
         writer
             .begin(
                 self.transcript_config.build_ceremony_info(ceremony),
-                self.transcript_config
-                    .build_instance_info(ceremony, resolved_params),
+                self.transcript_config.build_instance_info(
+                    ceremony,
+                    resolved_params,
+                    material_fingerprints,
+                ),
                 transcript_config::build_binary_info(),
                 transcript_config::build_image_info(),
                 transcript_config::build_initrd_measurements(),
@@ -271,8 +275,10 @@ impl<R: BufRead + Send, W: Write + Send> CeremonyExecutor<R, W> {
             .map(|(id, r)| (id.clone(), (r.name.clone(), r.person.clone())))
             .collect();
 
+        let material_fingerprints = collect_material_fingerprints(ceremony);
+
         let (mut transcript_writer, transcript_path) =
-            self.init_transcript(ceremony, &resolved_params, &roles)?;
+            self.init_transcript(ceremony, &resolved_params, &roles, material_fingerprints)?;
 
         printing::print_header(&mut self.writer, ceremony, self.dry_run)?;
 
@@ -466,7 +472,7 @@ fn execute_core(
         let event = ExecutionEvent {
             step_id: step.id.as_str().to_string(),
             action: step.action,
-            role: step.role.as_ref().map(|r| format!("${{{r}}}")),
+            role: step.role.as_ref().map(|r| r.as_str().to_string()),
             started_at,
             completed_at,
             outcome: crate::transcript::step_outcome_to_event_outcome(&result.outcome),
@@ -549,6 +555,30 @@ fn step_info_from(step: &Step) -> StepInfo {
         step.creates.clone(),
         step.reads_resolved.clone(),
     )
+}
+
+/// Compute SHA-256 fingerprints for all digital file-backed materials.
+///
+/// Physical materials and inline-identifier sources are skipped — they have no file to hash.
+/// Errors (e.g. file not readable) are silently ignored: the real error surfaces moments
+/// later when `execute_core` loads the material for use.
+fn collect_material_fingerprints(ceremony: &Ceremony) -> BTreeMap<String, String> {
+    ceremony
+        .materials
+        .iter()
+        .filter_map(|(id, material)| {
+            if let MaterialKind::Digital {
+                source: Some(MaterialSource::File { file }),
+            } = &material.kind
+            {
+                compute_file_fingerprint(file)
+                    .ok()
+                    .map(|fp| (id.as_str().to_string(), fp))
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 /// Load a single material into an `ArtifactValue`.

--- a/crates/rite-runtime/src/transcript.rs
+++ b/crates/rite-runtime/src/transcript.rs
@@ -626,7 +626,6 @@ mod tests {
             CeremonyInfo {
                 fingerprint: "sha256:ceremony123".to_string(),
                 name: "Test Ceremony".to_string(),
-                version: "1.0".to_string(),
             },
             None,
             BinaryInfo {
@@ -678,7 +677,6 @@ mod tests {
             CeremonyInfo {
                 fingerprint: "sha256:test".to_string(),
                 name: "Hash Chain Test".to_string(),
-                version: "1.0".to_string(),
             },
             None,
             BinaryInfo {
@@ -739,7 +737,6 @@ mod tests {
             CeremonyInfo {
                 fingerprint: "sha256:abc".to_string(),
                 name: "Test".to_string(),
-                version: "1.0".to_string(),
             },
             None,
             BinaryInfo {
@@ -773,7 +770,6 @@ mod tests {
             CeremonyInfo {
                 fingerprint: "sha256:abc".to_string(),
                 name: "Dry Run Test".to_string(),
-                version: "1.0".to_string(),
             },
             None,
             BinaryInfo {
@@ -807,11 +803,11 @@ mod tests {
             CeremonyInfo {
                 fingerprint: "sha256:abc".to_string(),
                 name: "Read Test".to_string(),
-                version: "1.0".to_string(),
             },
             Some(InstanceInfo {
                 fingerprint: "sha256:inst".to_string(),
                 parameters: BTreeMap::from([("key".to_string(), serde_json::json!("value"))]),
+                materials: BTreeMap::new(),
             }),
             BinaryInfo {
                 fingerprint: None,
@@ -855,7 +851,6 @@ mod tests {
             CeremonyInfo {
                 fingerprint: "sha256:abc".to_string(),
                 name: "Test".to_string(),
-                version: "1.0".to_string(),
             },
             None,
             BinaryInfo {
@@ -888,7 +883,6 @@ mod tests {
             CeremonyInfo {
                 fingerprint: "sha256:abc".to_string(),
                 name: "Test".to_string(),
-                version: "1.0".to_string(),
             },
             None,
             BinaryInfo {
@@ -937,7 +931,6 @@ mod tests {
                     "sha256:abc1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcd"
                         .to_string(),
                 name: "Sub-CA Key Ceremony".to_string(),
-                version: "1.0".to_string(),
             },
             instance: Some(InstanceInfo {
                 fingerprint:
@@ -947,6 +940,7 @@ mod tests {
                     ("ceremony_date".to_string(), serde_json::json!("2025-06-15")),
                     ("key_label".to_string(), serde_json::json!("SUB-CA-PROD")),
                 ]),
+                materials: BTreeMap::new(),
             }),
             binary: BinaryInfo {
                 fingerprint: None,
@@ -1073,7 +1067,6 @@ mod tests {
             ceremony: CeremonyInfo {
                 fingerprint: "sha256:test".to_string(),
                 name: "Test".to_string(),
-                version: "1.0".to_string(),
             },
             instance: None,
             binary: BinaryInfo {

--- a/crates/rite-runtime/src/transcript_config.rs
+++ b/crates/rite-runtime/src/transcript_config.rs
@@ -58,17 +58,18 @@ impl TranscriptConfig {
         CeremonyInfo {
             fingerprint,
             name: ceremony.metadata.name.clone(),
-            version: "1.0".to_string(),
         }
     }
 
     /// Build instance info for transcript.
     ///
-    /// The fingerprint is always computed from resolved parameter values.
+    /// The fingerprint covers all runtime inputs: parameter values and digital material
+    /// fingerprints. Physical materials have no digital identity and are excluded.
     pub fn build_instance_info<S: BuildHasher>(
         &self,
         ceremony: &Ceremony,
         resolved_params: &HashMap<ParamId, serde_json::Value, S>,
+        material_fingerprints: BTreeMap<String, String>,
     ) -> Option<InstanceInfo> {
         if ceremony.parameters.is_empty()
             && ceremony.materials.is_empty()
@@ -84,13 +85,18 @@ impl TranscriptConfig {
             .map(|(id, v)| (id.as_str().to_string(), v.clone()))
             .collect();
 
-        // Always compute fingerprint from resolved params
-        let json = serde_json::to_string(&string_params).unwrap_or_default();
+        // Fingerprint covers all runtime inputs: parameters and material fingerprints.
+        let combined = serde_json::json!({
+            "parameters": string_params,
+            "materials": material_fingerprints,
+        });
+        let json = serde_json::to_string(&combined).unwrap_or_default();
         let fingerprint = crate::transcript::compute_fingerprint(json.as_bytes());
 
         Some(InstanceInfo {
             fingerprint,
             parameters: string_params,
+            materials: material_fingerprints,
         })
     }
 }


### PR DESCRIPTION

- Add material fingerprints in instance
- Remove DSL expression syntax leak
- Remove `ceremony.version`
