### PR TITLE
fix(resolver,ls): tighten LSP span accuracy and lift navigation onto SpanMap

### DIFF
--- a/crates/rite-ls/src/goto.rs
+++ b/crates/rite-ls/src/goto.rs
@@ -1,16 +1,12 @@
 //! Go-to-definition for ceremony YAML.
 //!
-//! During `walk_spans`, the resolver collects a `ReferenceEntry` for every
-//! reference-value scalar it encounters (step `section:`, step/section `role:`,
-//! section `act:`). Each entry stores the source span of that value scalar plus
-//! the resolved declaration target.
-//!
-//! At request time we convert the LSP cursor (0-indexed) to 1-indexed coordinates,
-//! ask `SpanMap::find_target_at` for the matching entry, look up the target
-//! declaration's span in the same `SpanMap`, and return a `Location`.
+//! Maps the LSP cursor (0-indexed) to the resolver's 1-indexed coordinates,
+//! looks up the target via [`SpanMap::find_target_at`], then resolves it back
+//! to its declaration span via [`SpanMap::declaration_span`]. See
+//! [`rite_resolver::SpanMap`] for the reference-collection model.
 
 use crate::convert;
-use rite_resolver::{ReferenceTarget, SpanMap};
+use rite_resolver::SpanMap;
 use tower_lsp_server::ls_types::{GotoDefinitionResponse, Location, Position, Uri};
 
 /// Return a go-to-definition response for the cursor position, if applicable.
@@ -24,19 +20,58 @@ pub fn goto_definition_at(
     let col = pos.character as usize + 1;
 
     let target = span_map.find_target_at(line, col)?;
-
-    let decl_span = match target {
-        ReferenceTarget::Section(id) => span_map.sections.get(id).copied(),
-        ReferenceTarget::Role(id) => span_map.roles.get(id).copied(),
-        ReferenceTarget::Act(id) => span_map.acts.get(id).copied(),
-        ReferenceTarget::Param(id) => span_map.params.get(id).copied(),
-        ReferenceTarget::Material(id) => span_map.materials.get(id).copied(),
-        ReferenceTarget::Backend(name) => span_map.backends.get(name).copied(),
-    }?;
+    let decl_span = span_map.declaration_span(target)?;
 
     let target_pos = convert::span_to_position(decl_span);
     Some(GotoDefinitionResponse::Scalar(Location {
         uri: uri.clone(),
         range: convert::point_range(target_pos),
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rite_model::{ArtifactId, StepId};
+    use rite_resolver::{ReferenceContext, ReferenceEntry, ReferenceTarget, Span};
+
+    fn make_uri() -> Uri {
+        "file:///test.yaml".parse().unwrap()
+    }
+
+    #[test]
+    fn artifact_reference_resolves_to_creates_site() {
+        let mut span_map = SpanMap::default();
+        // `creates:` site at line 5 col 7.
+        let creates_span = Span {
+            line: 5,
+            column: 7,
+            length: Some(20),
+        };
+        span_map
+            .artifacts
+            .insert(ArtifactId::new("keypair"), creates_span);
+        // `reads:` reference at line 12 col 14 — cursor lands here.
+        span_map.references.push(ReferenceEntry {
+            span: Span {
+                line: 12,
+                column: 14,
+                length: Some(20),
+            },
+            target: ReferenceTarget::Artifact(ArtifactId::new("keypair")),
+            context: ReferenceContext::Step(StepId::new("use_step")),
+            value: "${artifact.keypair}".to_string(),
+        });
+
+        let pos = Position {
+            line: 11, // 0-indexed → 12
+            character: 14,
+        };
+        let resp = goto_definition_at(&span_map, pos, &make_uri())
+            .expect("should resolve artifact reference");
+        let GotoDefinitionResponse::Scalar(loc) = resp else {
+            panic!("expected Scalar response");
+        };
+        assert_eq!(loc.range.start.line, 4); // span line 5 → 0-indexed 4
+    }
 }

--- a/crates/rite-ls/src/hover.rs
+++ b/crates/rite-ls/src/hover.rs
@@ -2,17 +2,17 @@
 //!
 //! Two layers, tried in order:
 //!
-//! 1. **Reference hover**: uses `SpanMap::find_target_at` (the same mechanism as
-//!    go-to-definition) to detect when the cursor is over a `section:`, `role:`, or
-//!    `act:` value. If the resolved ceremony is available, shows the declaration's
-//!    name, description, and other metadata as Markdown.
+//! 1. **Reference hover**: `SpanMap::find_target_at` returns whichever
+//!    [`ReferenceTarget`] kind covers the cursor (section, role, act, param,
+//!    material, backend, artifact). If the resolved ceremony is available, the
+//!    target's metadata is rendered as Markdown.
 //!
 //! 2. **Action hover**: falls back to extracting the word at the cursor and looking
-//!    it up in the static action table. This is intentionally a fallback: it only fires
-//!    when the cursor is not on a known reference value.
+//!    it up in the static action table. Only fires when the cursor is not on a
+//!    known reference value.
 
 use crate::actions;
-use rite_model::{Ceremony, MaterialKind};
+use rite_model::{ArtifactId, Ceremony, MaterialId, MaterialKind};
 use rite_resolver::{ReferenceTarget, SpanMap};
 use tower_lsp_server::ls_types::{Hover, HoverContents, MarkupContent, MarkupKind, Position};
 
@@ -28,7 +28,7 @@ pub fn hover_at(
 
     span_map
         .find_target_at(line, col)
-        .and_then(|t| hover_for_target(t, resolved))
+        .and_then(|t| hover_for_target(t, span_map, resolved))
         .map(markdown_hover)
         .or_else(|| {
             let word = crate::convert::word_at_position(text, pos)?;
@@ -41,8 +41,18 @@ pub fn hover_at(
 /// Build Markdown hover content for a resolved reference target.
 ///
 /// Returns `None` if the target can't be found in the resolved ceremony
-/// (e.g., the file has errors and resolution failed).
-fn hover_for_target(target: &ReferenceTarget, resolved: Option<&Ceremony>) -> Option<String> {
+/// (e.g., the file has errors and resolution failed). Artifacts are handled
+/// separately because their hover content can be derived from `span_map` alone
+/// when the ceremony is unresolved.
+fn hover_for_target(
+    target: &ReferenceTarget,
+    span_map: &SpanMap,
+    resolved: Option<&Ceremony>,
+) -> Option<String> {
+    if let ReferenceTarget::Artifact(id) = target {
+        return Some(artifact_hover(id, span_map, resolved));
+    }
+
     let resolved = resolved?;
     match target {
         ReferenceTarget::Section(id) => {
@@ -114,7 +124,40 @@ fn hover_for_target(target: &ReferenceTarget, resolved: Option<&Ceremony>) -> Op
                 backend.provider
             ))
         }
+        // ReferenceTarget is `#[non_exhaustive]`; Artifact is handled by the
+        // early-return above, so no other variant currently reaches this arm.
+        _ => None,
     }
+}
+
+/// Render hover content for an artifact reference, using `span_map` to
+/// distinguish a `creates:`-produced artifact from a material-backed one.
+/// Falls back to the bare ID when no metadata is available — never returns
+/// `None`, so the action-table fallback in `hover_at` doesn't fire on the
+/// same word.
+fn artifact_hover(id: &ArtifactId, span_map: &SpanMap, resolved: Option<&Ceremony>) -> String {
+    if span_map.artifacts.contains_key(id) {
+        // TODO: name the producing step (`produced by step \`gen_step\``) once a
+        // `creates_by_step: HashMap<ArtifactId, StepId>` lives on `SpanMap`.
+        return format!("**artifact** `{id}` · produced upstream");
+    }
+    if let Some(ceremony) = resolved
+        && let Some(material) = ceremony.materials.get(&MaterialId::new(id.as_str()))
+    {
+        let kind_str = match &material.kind {
+            MaterialKind::Digital { .. } => "digital",
+            MaterialKind::Physical { .. } => "physical",
+        };
+        let mut md = format!("**artifact** `{id}` · material · `{kind_str}`");
+        if let Some(title) = &material.title {
+            md.push_str(&format!("\n\n{title}"));
+        }
+        if let Some(desc) = &material.description {
+            md.push_str(&format!("\n\n{desc}"));
+        }
+        return md;
+    }
+    format!("**artifact** `{id}`")
 }
 
 fn markdown_hover(value: String) -> Hover {
@@ -130,6 +173,8 @@ fn markdown_hover(value: String) -> Hover {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rite_model::{ArtifactId, StepId};
+    use rite_resolver::{ReferenceContext, ReferenceEntry, Span};
 
     #[test]
     fn extracts_word_at_middle() {
@@ -164,5 +209,70 @@ mod tests {
             character: 14,
         };
         assert!(hover_at(text, &span_map, None, pos).is_none());
+    }
+
+    #[test]
+    fn artifact_hover_says_produced_when_creates_site_present() {
+        let mut span_map = SpanMap::default();
+        span_map.artifacts.insert(
+            ArtifactId::new("keypair"),
+            Span {
+                line: 5,
+                column: 7,
+                length: Some(20),
+            },
+        );
+        span_map.references.push(ReferenceEntry {
+            span: Span {
+                line: 12,
+                column: 14,
+                length: Some(20),
+            },
+            target: ReferenceTarget::Artifact(ArtifactId::new("keypair")),
+            context: ReferenceContext::Step(StepId::new("use_step")),
+            value: "${artifact.keypair}".to_string(),
+        });
+
+        let pos = Position {
+            line: 11,
+            character: 14,
+        };
+        let hover = hover_at("", &span_map, None, pos).expect("hover");
+        if let HoverContents::Markup(MarkupContent { value, .. }) = hover.contents {
+            assert!(value.contains("produced"), "got: {value}");
+            assert!(value.contains("keypair"), "got: {value}");
+        } else {
+            panic!("expected markup hover");
+        }
+    }
+
+    #[test]
+    fn artifact_hover_falls_through_to_basic_when_no_metadata() {
+        // No `creates:` site recorded and no resolved ceremony to look up
+        // material details — should still produce a basic artifact hover so
+        // the action-table fallback doesn't misfire on the same word.
+        let mut span_map = SpanMap::default();
+        span_map.references.push(ReferenceEntry {
+            span: Span {
+                line: 12,
+                column: 14,
+                length: Some(15),
+            },
+            target: ReferenceTarget::Artifact(ArtifactId::new("ghost")),
+            context: ReferenceContext::Step(StepId::new("use_step")),
+            value: "${artifact.ghost}".to_string(),
+        });
+
+        let pos = Position {
+            line: 11,
+            character: 14,
+        };
+        let hover = hover_at("", &span_map, None, pos).expect("hover");
+        if let HoverContents::Markup(MarkupContent { value, .. }) = hover.contents {
+            assert!(value.contains("ghost"), "got: {value}");
+            assert!(!value.contains("produced"), "got: {value}");
+        } else {
+            panic!("expected markup hover");
+        }
     }
 }

--- a/crates/rite-ls/src/references.rs
+++ b/crates/rite-ls/src/references.rs
@@ -1,12 +1,12 @@
 //! Find-references for ceremony YAML.
 //!
-//! Given a cursor position, identifies the declaration target under the cursor
-//! (whether the cursor is on a reference value or a declaration key) and returns
-//! all `Location`s in the document that reference that same target.
+//! Identifies the declaration target under the cursor (whether the cursor is
+//! on a reference value or a declaration key) and returns every `Location`
+//! that references that target. Lookups delegate to `SpanMap`. See
+//! [`rite_resolver::SpanMap`] for the reference-collection model.
 
 use crate::convert;
-use rite_model::{ActId, MaterialId, ParamId, RoleId, SectionId};
-use rite_resolver::{ReferenceTarget, Span, SpanMap};
+use rite_resolver::SpanMap;
 use tower_lsp_server::ls_types::{Location, Position, Uri};
 
 /// Return all reference sites for the target at the cursor position.
@@ -14,11 +14,12 @@ use tower_lsp_server::ls_types::{Location, Position, Uri};
 /// Works in two cases:
 /// 1. Cursor is on a **reference value** (e.g. the `main` in `section: main`):
 ///    `find_target_at` identifies the target directly.
-/// 2. Cursor is on a **declaration key** (e.g. the `main` in `- id: main` under
-///    `sections:`): the word under the cursor is matched against declaration maps.
+/// 2. Cursor is on a **declaration key** (e.g. the `main` in `sections.main:`):
+///    the word under the cursor is matched against declaration maps via
+///    `SpanMap::declaration_target_for_word`.
 ///
-/// When `include_declaration` is true (matching `ReferenceContext.include_declaration` from the
-/// LSP client), the declaration site is prepended to the returned list.
+/// When `include_declaration` is true the declaration site is prepended to the
+/// returned list (matching the LSP `ReferenceContext.includeDeclaration` flag).
 ///
 /// Returns an empty vec if no known target is under the cursor.
 pub fn find_references_at(
@@ -32,93 +33,41 @@ pub fn find_references_at(
     let line_1 = pos.line as usize + 1;
     let col_1 = pos.character as usize + 1;
 
-    // Try: cursor is on a reference value.
     let target = if let Some(t) = span_map.find_target_at(line_1, col_1) {
         t.clone()
     } else {
-        // Try: cursor is on a declaration.
         let word = crate::convert::word_at_position(text, pos).unwrap_or_default();
         if word.is_empty() {
             return vec![];
         }
-        if let Some(target) = declaration_target(span_map, &word) {
-            target
-        } else {
+        let Some(target) = span_map.declaration_target_for_word(&word) else {
             return vec![];
-        }
+        };
+        target
     };
 
     let mut locs: Vec<Location> = Vec::new();
 
-    // Prepend the declaration site when the client requests it.
-    if include_declaration && let Some(decl_span) = decl_span_for_target(span_map, &target) {
+    if include_declaration && let Some(decl_span) = span_map.declaration_span(&target) {
         locs.push(Location {
             uri: uri.clone(),
             range: convert::point_range(convert::span_to_position(decl_span)),
         });
     }
 
-    locs.extend(
-        span_map
-            .references
-            .iter()
-            .filter(|e| e.target == target)
-            .map(|e| Location {
-                uri: uri.clone(),
-                range: convert::span_to_range(e.span),
-            }),
-    );
+    locs.extend(span_map.references_for_target(&target).map(|e| Location {
+        uri: uri.clone(),
+        range: convert::span_to_range(e.span),
+    }));
 
     locs
-}
-
-/// Look up the declaration span for a resolved reference target.
-fn decl_span_for_target(span_map: &SpanMap, target: &ReferenceTarget) -> Option<Span> {
-    match target {
-        ReferenceTarget::Section(id) => span_map.sections.get(id).copied(),
-        ReferenceTarget::Role(id) => span_map.roles.get(id).copied(),
-        ReferenceTarget::Act(id) => span_map.acts.get(id).copied(),
-        ReferenceTarget::Param(id) => span_map.params.get(id).copied(),
-        ReferenceTarget::Material(id) => span_map.materials.get(id).copied(),
-        ReferenceTarget::Backend(name) => span_map.backends.get(name.as_str()).copied(),
-    }
-}
-
-/// Identify a declaration target if `word` matches a known declaration ID.
-///
-/// Checks all declaration maps and returns the first match found.
-fn declaration_target(span_map: &SpanMap, word: &str) -> Option<ReferenceTarget> {
-    let section_id = SectionId::new(word);
-    if span_map.sections.contains_key(&section_id) {
-        return Some(ReferenceTarget::Section(section_id));
-    }
-    let role_id = RoleId::new(word);
-    if span_map.roles.contains_key(&role_id) {
-        return Some(ReferenceTarget::Role(role_id));
-    }
-    let act_id = ActId::new(word);
-    if span_map.acts.contains_key(&act_id) {
-        return Some(ReferenceTarget::Act(act_id));
-    }
-    let param_id = ParamId::new(word);
-    if span_map.params.contains_key(&param_id) {
-        return Some(ReferenceTarget::Param(param_id));
-    }
-    let material_id = MaterialId::new(word);
-    if span_map.materials.contains_key(&material_id) {
-        return Some(ReferenceTarget::Material(material_id));
-    }
-    if span_map.backends.contains_key(word) {
-        return Some(ReferenceTarget::Backend(word.to_string()));
-    }
-    None
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rite_model::StepId;
-    use rite_resolver::{ReferenceContext, ReferenceEntry, Span};
+    use rite_model::{ArtifactId, SectionId, StepId};
+    use rite_resolver::{ReferenceContext, ReferenceEntry, ReferenceTarget, Span};
 
     fn make_uri() -> Uri {
         "file:///test.yaml".parse().unwrap()
@@ -143,6 +92,7 @@ mod tests {
             },
             target: ReferenceTarget::Section(SectionId::new("main")),
             context: ReferenceContext::Step(StepId::new("test")),
+            value: "main".to_string(),
         });
         span_map.references.push(ReferenceEntry {
             span: Span {
@@ -151,6 +101,7 @@ mod tests {
             },
             target: ReferenceTarget::Section(SectionId::new("main")),
             context: ReferenceContext::Step(StepId::new("test")),
+            value: "main".to_string(),
         });
         span_map.references.push(ReferenceEntry {
             span: Span {
@@ -159,6 +110,7 @@ mod tests {
             },
             target: ReferenceTarget::Section(SectionId::new("other")),
             context: ReferenceContext::Step(StepId::new("test")),
+            value: "other".to_string(),
         });
 
         // Cursor on the first reference value (line 10, col 15 → 0-indexed: 9, 14).
@@ -185,6 +137,7 @@ mod tests {
             },
             target: ReferenceTarget::Section(SectionId::new("setup")),
             context: ReferenceContext::Step(StepId::new("test")),
+            value: "setup".to_string(),
         });
 
         // Cursor on the declaration itself (not a reference), word = "setup".
@@ -220,9 +173,9 @@ mod tests {
             },
             target: ReferenceTarget::Section(SectionId::new("main")),
             context: ReferenceContext::Step(StepId::new("test")),
+            value: "main".to_string(),
         });
 
-        // Cursor on the reference value.
         let pos = Position {
             line: 9,
             character: 14,
@@ -232,5 +185,48 @@ mod tests {
         // Declaration site (span line 5 → 0-indexed 4) comes first.
         assert_eq!(locs[0].range.start.line, 4);
         assert_eq!(locs[1].range.start.line, 9);
+    }
+
+    #[test]
+    fn finds_artifact_references_from_creates_or_reads() {
+        // Cursor on the `${artifact.keypair}` value in a `reads:` block should
+        // find both the producing `creates:` site (when include_declaration is
+        // on) and every `reads:` use.
+        let mut span_map = SpanMap::default();
+        let creates_span = Span {
+            line: 5,
+            column: 7,
+            length: Some(20),
+        };
+        span_map
+            .artifacts
+            .insert(ArtifactId::new("keypair"), creates_span);
+        // `creates:` reference entry.
+        span_map.references.push(ReferenceEntry {
+            span: creates_span,
+            target: ReferenceTarget::Artifact(ArtifactId::new("keypair")),
+            context: ReferenceContext::Step(StepId::new("gen_step")),
+            value: "${artifact.keypair}".to_string(),
+        });
+        // `reads:` reference entry — cursor lands here.
+        span_map.references.push(ReferenceEntry {
+            span: Span {
+                line: 12,
+                column: 14,
+                length: Some(20),
+            },
+            target: ReferenceTarget::Artifact(ArtifactId::new("keypair")),
+            context: ReferenceContext::Step(StepId::new("use_step")),
+            value: "${artifact.keypair}".to_string(),
+        });
+
+        let pos = Position {
+            line: 11,
+            character: 14,
+        };
+        let locs = find_references_at(&span_map, "", pos, &make_uri(), true);
+        // 1 declaration + 2 reference entries (creates: and reads:).
+        assert_eq!(locs.len(), 3);
+        assert_eq!(locs[0].range.start.line, 4); // declaration at line 5
     }
 }

--- a/crates/rite-resolver/src/diagnostic.rs
+++ b/crates/rite-resolver/src/diagnostic.rs
@@ -1,7 +1,7 @@
 //! Diagnostic types for ceremony validation with source location tracking.
 
 use crate::error::{ResolveError, ResolveWarning};
-use rite_model::{ActId, MaterialId, ParamId, RoleId, SectionId, StepId};
+use rite_model::{ActId, ArtifactId, MaterialId, OutputId, ParamId, RoleId, SectionId, StepId};
 use std::collections::HashMap;
 use std::fmt;
 use std::path::{Path, PathBuf};
@@ -90,6 +90,7 @@ impl fmt::Display for ReferenceContext {
 
 /// The kind of declaration a reference points to.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum ReferenceTarget {
     /// A section declaration.
     Section(SectionId),
@@ -103,6 +104,9 @@ pub enum ReferenceTarget {
     Material(MaterialId),
     /// A backend declaration.
     Backend(String),
+    /// An artifact reference (resolves to either a `materials:` declaration or
+    /// the `creates:` of an upstream step).
+    Artifact(ArtifactId),
 }
 
 /// A single reference site collected during span walking.
@@ -118,9 +122,27 @@ pub struct ReferenceEntry {
     pub target: ReferenceTarget,
     /// The owning step or section.
     pub context: ReferenceContext,
+    /// The raw source slice covered by `span` (e.g. `${role.alice}`, `${param.x}`,
+    /// or a bare `alice`). Enables span lookup by raw value text without re-reading
+    /// the YAML source — see `SpanMap::span_for_value`.
+    pub value: String,
 }
 
-/// Maps ceremony element IDs to their source positions for diagnostic enrichment.
+/// Maps ceremony element IDs to their source positions for diagnostic enrichment
+/// and editor navigation.
+///
+/// The resolver's `Lowerer` populates this in a single pass over the parsed YAML.
+/// Declaration spans (one map per kind) record where each ID is defined; the
+/// `references` vector records every reference-value scalar — `role:`, `act:`,
+/// `backend:`, `creates:`, `reads:`, plus `${param.x}` / `${material.x}` /
+/// `${artifact.x}` / `${role.x}` expressions inside `description:` and `with:`
+/// blocks. Each reference entry stores its source span, resolved target, owning
+/// step or section, and the raw source text.
+///
+/// Consumers (LSP for navigation, `rite check`/`rite run` for diagnostic spans)
+/// should use the `SpanMap` methods rather than the public maps directly when a
+/// helper exists — that keeps the lookup rules (e.g. artifact→material fallback)
+/// in one place.
 #[derive(Default)]
 pub struct SpanMap {
     /// Step declaration spans.
@@ -137,6 +159,10 @@ pub struct SpanMap {
     pub materials: HashMap<MaterialId, Span>,
     /// Declaration spans for `backends:` map keys.
     pub backends: HashMap<String, Span>,
+    /// Output declaration spans (top-level `output:` map keys).
+    pub outputs: HashMap<OutputId, Span>,
+    /// Spans of the `creates:` value scalars that produce each artifact ID.
+    pub artifacts: HashMap<ArtifactId, Span>,
     /// Reference sites collected during parsing: value-scalar span → declaration target.
     /// Used by go-to-definition to map a cursor position to a declaration span.
     pub references: Vec<ReferenceEntry>,
@@ -157,6 +183,73 @@ impl SpanMap {
                 None
             }
         })
+    }
+
+    /// Look up the declaration span for a resolved [`ReferenceTarget`].
+    ///
+    /// For artifacts the "declaration" is the producing step's `creates:` site;
+    /// when no producer is recorded we fall back to a same-named material entry
+    /// (since `${artifact.X}` may resolve to a `materials:` declaration).
+    pub fn declaration_span(&self, target: &ReferenceTarget) -> Option<Span> {
+        match target {
+            ReferenceTarget::Section(id) => self.sections.get(id).copied(),
+            ReferenceTarget::Role(id) => self.roles.get(id).copied(),
+            ReferenceTarget::Act(id) => self.acts.get(id).copied(),
+            ReferenceTarget::Param(id) => self.params.get(id).copied(),
+            ReferenceTarget::Material(id) => self.materials.get(id).copied(),
+            ReferenceTarget::Backend(name) => self.backends.get(name.as_str()).copied(),
+            ReferenceTarget::Artifact(id) => self
+                .artifacts
+                .get(id)
+                .copied()
+                .or_else(|| self.materials.get(&MaterialId::new(id.as_str())).copied()),
+        }
+    }
+
+    /// Identify the [`ReferenceTarget`] kind a free-form `word` declares.
+    ///
+    /// Used when the cursor is on a declaration key (rather than a reference value)
+    /// to pivot from `find-references` back into the same target type. The first
+    /// matching map wins.
+    pub fn declaration_target_for_word(&self, word: &str) -> Option<ReferenceTarget> {
+        let section_id = SectionId::new(word);
+        if self.sections.contains_key(&section_id) {
+            return Some(ReferenceTarget::Section(section_id));
+        }
+        let role_id = RoleId::new(word);
+        if self.roles.contains_key(&role_id) {
+            return Some(ReferenceTarget::Role(role_id));
+        }
+        let act_id = ActId::new(word);
+        if self.acts.contains_key(&act_id) {
+            return Some(ReferenceTarget::Act(act_id));
+        }
+        let param_id = ParamId::new(word);
+        if self.params.contains_key(&param_id) {
+            return Some(ReferenceTarget::Param(param_id));
+        }
+        let material_id = MaterialId::new(word);
+        if self.materials.contains_key(&material_id) {
+            return Some(ReferenceTarget::Material(material_id));
+        }
+        let artifact_id = ArtifactId::new(word);
+        if self.artifacts.contains_key(&artifact_id) {
+            return Some(ReferenceTarget::Artifact(artifact_id));
+        }
+        if self.backends.contains_key(word) {
+            return Some(ReferenceTarget::Backend(word.to_string()));
+        }
+        None
+    }
+
+    /// Iterate every reference entry whose target matches `target`.
+    ///
+    /// Used by find-references to enumerate the use sites of a declaration.
+    pub fn references_for_target<'a>(
+        &'a self,
+        target: &'a ReferenceTarget,
+    ) -> impl Iterator<Item = &'a ReferenceEntry> + 'a {
+        self.references.iter().filter(move |e| e.target == *target)
     }
 
     /// Convert a `ResolveError` to a `Diagnostic`, looking up the best available span.
@@ -181,6 +274,9 @@ impl SpanMap {
         }
     }
 
+    // TODO: pair this exhaustive match with a `#[cfg(test)] fn variant_name(&ResolveError)`
+    // sentinel + a constructors-list test, so a new variant fails not only here but
+    // also in the dispatch test table (`lib.rs`).
     fn span_for_error(&self, err: &ResolveError) -> Option<Span> {
         match err {
             ResolveError::Yaml { location, .. } => location.map(|(line, col)| Span {
@@ -190,7 +286,6 @@ impl SpanMap {
             }),
             ResolveError::Io { .. }
             | ResolveError::UnsupportedVersion { .. }
-            | ResolveError::DuplicateOutput(_)
             | ResolveError::DutyUnknownRole { .. }
             | ResolveError::CustomDutyMissingDescription { .. } => None,
             ResolveError::DuplicateRole(id) => self.roles.get(id).copied(),
@@ -199,6 +294,7 @@ impl SpanMap {
             ResolveError::DuplicateAct(id) => self.acts.get(id).copied(),
             ResolveError::DuplicateParam(id) => self.params.get(id).copied(),
             ResolveError::DuplicateMaterial(id) => self.materials.get(id).copied(),
+            ResolveError::DuplicateOutput(id) => self.outputs.get(id).copied(),
             ResolveError::UnknownSection { step, .. }
             | ResolveError::UnknownArtifact { step, .. }
             | ResolveError::MissingRequiredBackend { step, .. }
@@ -219,8 +315,10 @@ impl SpanMap {
                     &ReferenceContext::Section(section.clone()),
                 )
                 .or_else(|| self.sections.get(section).copied()),
-            ResolveError::InvalidReferenceSyntax { context, .. }
-            | ResolveError::ReferenceTypeMismatch { context, .. } => self.span_for_context(context),
+            ResolveError::InvalidReferenceSyntax { context, value, .. }
+            | ResolveError::ReferenceTypeMismatch { context, value, .. } => self
+                .span_for_value(context, value)
+                .or_else(|| self.span_for_context(context)),
             ResolveError::ArtifactUsedBeforeProduced { used_in, .. } => {
                 self.steps.get(used_in).copied()
             }
@@ -252,6 +350,19 @@ impl SpanMap {
             .map(|e| e.span)
     }
 
+    /// Look up the span of a reference by raw source text and owning context.
+    ///
+    /// Used by `span_for_error` when only the literal value is known (e.g. for
+    /// `InvalidReferenceSyntax` and `ReferenceTypeMismatch`, where the value did
+    /// not parse as any specific reference kind). Matches whichever entry covers
+    /// the same source slice in the same step or section.
+    fn span_for_value(&self, context: &ReferenceContext, value: &str) -> Option<Span> {
+        self.references
+            .iter()
+            .find(|e| e.context == *context && e.value == value)
+            .map(|e| e.span)
+    }
+
     /// Look up a declaration span for a context (step or section).
     fn span_for_context(&self, context: &ReferenceContext) -> Option<Span> {
         match context {
@@ -264,9 +375,135 @@ impl SpanMap {
         match w {
             ResolveWarning::UnusedParam(id) => self.params.get(id).copied(),
             ResolveWarning::UnusedMaterial(id) => self.materials.get(id).copied(),
-            ResolveWarning::UnusedOutput(_) | ResolveWarning::ArtifactNotOutput(_) => None,
+            ResolveWarning::UnusedOutput(id) => self.outputs.get(id).copied(),
+            ResolveWarning::ArtifactNotOutput(id) => self.artifacts.get(id).copied(),
             ResolveWarning::UnknownRoleInInputs { role } => self.roles.get(role).copied(),
             ResolveWarning::UnusedBackend { step } => self.steps.get(step).copied(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn point_span(line: usize, column: usize, length: usize) -> Span {
+        Span {
+            line,
+            column,
+            length: Some(length),
+        }
+    }
+
+    #[test]
+    fn declaration_span_dispatches_per_target_kind() {
+        let mut span_map = SpanMap::default();
+        span_map
+            .roles
+            .insert(RoleId::new("alice"), point_span(3, 5, 5));
+        span_map
+            .materials
+            .insert(MaterialId::new("card"), point_span(7, 5, 4));
+        span_map
+            .backends
+            .insert("ssl".to_string(), point_span(9, 5, 3));
+
+        let role_span = span_map
+            .declaration_span(&ReferenceTarget::Role(RoleId::new("alice")))
+            .expect("role span");
+        assert_eq!(role_span.line, 3);
+
+        let material_span = span_map
+            .declaration_span(&ReferenceTarget::Material(MaterialId::new("card")))
+            .expect("material span");
+        assert_eq!(material_span.line, 7);
+
+        let backend_span = span_map
+            .declaration_span(&ReferenceTarget::Backend("ssl".to_string()))
+            .expect("backend span");
+        assert_eq!(backend_span.line, 9);
+    }
+
+    #[test]
+    fn declaration_span_for_artifact_falls_back_to_material() {
+        // No producing step recorded for the artifact, but a same-named material
+        // declaration exists. `${artifact.X}` resolves to that material at IR time;
+        // the span lookup must mirror that resolution.
+        let mut span_map = SpanMap::default();
+        span_map
+            .materials
+            .insert(MaterialId::new("seed"), point_span(11, 5, 4));
+
+        let span = span_map
+            .declaration_span(&ReferenceTarget::Artifact(ArtifactId::new("seed")))
+            .expect("should fall back to material span");
+        assert_eq!(span.line, 11);
+    }
+
+    #[test]
+    fn declaration_target_for_word_resolves_each_kind() {
+        let mut span_map = SpanMap::default();
+        span_map
+            .sections
+            .insert(SectionId::new("setup"), point_span(2, 3, 5));
+        span_map
+            .roles
+            .insert(RoleId::new("alice"), point_span(4, 3, 5));
+        span_map
+            .params
+            .insert(ParamId::new("threshold"), point_span(6, 3, 9));
+        span_map
+            .artifacts
+            .insert(ArtifactId::new("keypair"), point_span(8, 3, 7));
+
+        assert!(matches!(
+            span_map.declaration_target_for_word("setup"),
+            Some(ReferenceTarget::Section(_))
+        ));
+        assert!(matches!(
+            span_map.declaration_target_for_word("alice"),
+            Some(ReferenceTarget::Role(_))
+        ));
+        assert!(matches!(
+            span_map.declaration_target_for_word("threshold"),
+            Some(ReferenceTarget::Param(_))
+        ));
+        assert!(matches!(
+            span_map.declaration_target_for_word("keypair"),
+            Some(ReferenceTarget::Artifact(_))
+        ));
+        assert!(span_map.declaration_target_for_word("nope").is_none());
+    }
+
+    #[test]
+    fn references_for_target_filters_by_target_only() {
+        let mut span_map = SpanMap::default();
+        let ctx_a = ReferenceContext::Step(StepId::new("a"));
+        let ctx_b = ReferenceContext::Step(StepId::new("b"));
+        span_map.references.push(ReferenceEntry {
+            span: point_span(10, 3, 4),
+            target: ReferenceTarget::Section(SectionId::new("main")),
+            context: ctx_a.clone(),
+            value: "main".to_string(),
+        });
+        span_map.references.push(ReferenceEntry {
+            span: point_span(20, 3, 4),
+            target: ReferenceTarget::Section(SectionId::new("main")),
+            context: ctx_b,
+            value: "main".to_string(),
+        });
+        span_map.references.push(ReferenceEntry {
+            span: point_span(30, 3, 5),
+            target: ReferenceTarget::Section(SectionId::new("other")),
+            context: ctx_a,
+            value: "other".to_string(),
+        });
+
+        let main = ReferenceTarget::Section(SectionId::new("main"));
+        let lines: Vec<usize> = span_map
+            .references_for_target(&main)
+            .map(|e| e.span.line)
+            .collect();
+        assert_eq!(lines, vec![10, 20]);
     }
 }

--- a/crates/rite-resolver/src/error.rs
+++ b/crates/rite-resolver/src/error.rs
@@ -256,6 +256,8 @@ pub enum ResolveError {
         expected: RefType,
         /// The actual reference type.
         actual: RefType,
+        /// The raw reference string, used to look up the expression span.
+        value: String,
     },
 }
 

--- a/crates/rite-resolver/src/lib.rs
+++ b/crates/rite-resolver/src/lib.rs
@@ -26,6 +26,9 @@ mod resolve;
 mod schema;
 mod serde_utils;
 
+#[cfg(test)]
+pub(crate) mod test_helpers;
+
 pub use diagnostic::{
     Diagnostic, ReferenceContext, ReferenceEntry, ReferenceTarget, Severity, Span, SpanMap,
 };
@@ -211,6 +214,7 @@ pub fn analyze(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_helpers::span_text;
     use rite_model::{ParamId, RoleId};
 
     #[test]
@@ -354,5 +358,352 @@ sections:
             e,
             ResolveError::UnknownRole { role, .. } if role.as_str() == "nonexistent"
         )));
+    }
+
+    #[test]
+    fn invalid_role_ref_diagnostic_spans_the_expression_not_the_step() {
+        // When `role: "${xxxx}"` fails to parse as a valid role reference, the
+        // diagnostic must underline "${xxxx}" — the expression that is wrong —
+        // not the step key "my_step" where the reference happens to live.
+        let yaml = r#"
+version: "0.2"
+name: "Test"
+roles:
+  alice: {}
+sections:
+  main:
+    steps:
+      my_step:
+        action: confirm
+        role: "${xxxx}"
+"#;
+        let (_, _, diags) = analyze_str(None, yaml);
+        let diag = diags
+            .iter()
+            .find(|d| d.message.contains("Invalid reference syntax"))
+            .expect("should have an InvalidReferenceSyntax diagnostic");
+        let span = diag.span.expect("diagnostic must have a span");
+
+        // The span must cover "${xxxx}" (7 chars), not "my_step" or any other token.
+        assert_eq!(
+            span_text(yaml, span),
+            "${xxxx}",
+            "diagnostic should underline the bad expression, not the enclosing step key"
+        );
+    }
+
+    #[test]
+    fn unknown_role_diagnostic_spans_the_full_expression() {
+        // When `role: "${role.ghost}"` references a role that does not exist,
+        // the diagnostic must underline the entire "${role.ghost}" expression.
+        let yaml = r#"
+version: "0.2"
+name: "Test"
+roles:
+  alice: {}
+sections:
+  main:
+    steps:
+      my_step:
+        action: confirm
+        role: "${role.ghost}"
+"#;
+        let (_, _, diags) = analyze_str(None, yaml);
+        let diag = diags
+            .iter()
+            .find(|d| d.message.contains("Unknown role") && d.message.contains("ghost"))
+            .expect("should have an UnknownRole diagnostic");
+        let span = diag.span.expect("diagnostic must have a span");
+
+        // Must cover "${role.ghost}" (13 chars), not just "ghost".
+        assert_eq!(
+            span_text(yaml, span),
+            "${role.ghost}",
+            "diagnostic should underline the full expression including the ${{...}} delimiters"
+        );
+    }
+
+    #[test]
+    fn missing_action_diagnostic_spans_step_id_with_full_length() {
+        // The "step is missing required field 'action'" diagnostic must point at
+        // the step key ("my_step") with its full length, so editors can underline
+        // the identifier rather than showing a zero-width squiggly.
+        let yaml = r#"
+version: "0.2"
+name: "Test"
+roles: {}
+sections:
+  main:
+    steps:
+      my_step:
+        description: "hello"
+"#;
+        let (_, _, diags) = analyze_str(None, yaml);
+        let diag = diags
+            .iter()
+            .find(|d| d.message.contains("missing required field 'action'"))
+            .expect("should have a missing-action diagnostic");
+        let span = diag.span.expect("diagnostic must have a span");
+
+        // Must cover "my_step" — the step ID key — not "description" or empty.
+        assert_eq!(
+            span_text(yaml, span),
+            "my_step",
+            "missing-action diagnostic should underline the step key with its full length"
+        );
+    }
+
+    #[test]
+    fn missing_required_backend_diagnostic_spans_step_id() {
+        let yaml = r#"
+version: "0.2"
+name: "Test"
+roles: {}
+sections:
+  main:
+    steps:
+      gen:
+        action: generate_keypair
+"#;
+        let (_, _, diags) = analyze_str(None, yaml);
+        let diag = diags
+            .iter()
+            .find(|d| d.message.contains("requires a backend"))
+            .expect("should have a missing-backend diagnostic");
+        let span = diag.span.expect("diagnostic must have a span");
+        assert_eq!(span_text(yaml, span), "gen");
+    }
+
+    #[test]
+    fn artifact_reference_type_mismatch_diagnostic_spans_the_expression() {
+        // Artifact-typed `reads:` field given a role-typed expression. The
+        // generic value-span lookup must find the entry pushed by the
+        // `reads:` walk and underline the expression — not the step key.
+        let yaml = r#"
+version: "0.2"
+name: "Test"
+roles:
+  alice: {}
+sections:
+  main:
+    steps:
+      my_step:
+        action: confirm
+        reads: "${role.alice}"
+"#;
+        let (_, _, diags) = analyze_str(None, yaml);
+        let diag = diags
+            .iter()
+            .find(|d| d.message.contains("Reference type mismatch"))
+            .expect("should have a ReferenceTypeMismatch diagnostic");
+        let span = diag.span.expect("diagnostic must have a span");
+        assert_eq!(span_text(yaml, span), "${role.alice}");
+    }
+
+    // ── span_for_error dispatch coverage ──────────────────────────────────────
+    //
+    // These tests exercise `SpanMap::to_diagnostic` directly so each `ResolveError`
+    // variant can be span-checked without having to construct YAML that triggers
+    // the variant through resolution. Add a row here whenever a new variant lands.
+    //
+    // TODO: collapse into a `&[SpanCase { name, make_err, expected }]` table once
+    // the variant count grows; pair with the exhaustiveness sentinel in
+    // `diagnostic.rs::span_for_error` so missing rows fail fast.
+
+    use crate::diagnostic::{Severity, SpanMap};
+    use rite_model::{ActId, ArtifactId, MaterialId, OutputId, SectionId, StepId};
+
+    fn span_map_for(yaml: &str) -> SpanMap {
+        let (_, span_map, _) = analyze_str(None, yaml);
+        span_map
+    }
+
+    fn dispatch_span_text(yaml: &str, span_map: &SpanMap, err: &ResolveError) -> String {
+        let diag = span_map.to_diagnostic(None, err);
+        assert_eq!(diag.severity, Severity::Error);
+        let span = diag
+            .span
+            .unwrap_or_else(|| panic!("dispatch returned no span for {err:?}"));
+        span_text(yaml, span).to_string()
+    }
+
+    fn dispatch_warning_span_text(
+        yaml: &str,
+        span_map: &SpanMap,
+        warning: &ResolveWarning,
+    ) -> String {
+        let diag = span_map.warning_to_diagnostic(None, warning);
+        assert_eq!(diag.severity, Severity::Warning);
+        let span = diag
+            .span
+            .unwrap_or_else(|| panic!("dispatch returned no span for {warning:?}"));
+        span_text(yaml, span).to_string()
+    }
+
+    const DISPATCH_YAML: &str = r#"
+version: "0.2"
+name: "Test"
+roles:
+  alice: {}
+acts:
+  - id: setup
+    name: Setup
+sections:
+  main:
+    act: setup
+    steps:
+      my_step:
+        action: confirm
+        creates: "${artifact.my_artifact}"
+parameters:
+  my_param:
+    type: string
+materials:
+  my_material:
+    type: digital
+backends:
+  ssl:
+    provider: openssl
+output:
+  signed_cert:
+    type: artifact
+"#;
+
+    #[test]
+    fn dispatch_duplicate_role_spans_role_id() {
+        let span_map = span_map_for(DISPATCH_YAML);
+        let text = dispatch_span_text(
+            DISPATCH_YAML,
+            &span_map,
+            &ResolveError::DuplicateRole(RoleId::new("alice")),
+        );
+        assert_eq!(text, "alice");
+    }
+
+    #[test]
+    fn dispatch_duplicate_step_spans_step_id() {
+        let span_map = span_map_for(DISPATCH_YAML);
+        let text = dispatch_span_text(
+            DISPATCH_YAML,
+            &span_map,
+            &ResolveError::DuplicateStep(StepId::new("my_step")),
+        );
+        assert_eq!(text, "my_step");
+    }
+
+    #[test]
+    fn dispatch_duplicate_section_spans_section_id() {
+        let span_map = span_map_for(DISPATCH_YAML);
+        let text = dispatch_span_text(
+            DISPATCH_YAML,
+            &span_map,
+            &ResolveError::DuplicateSection(SectionId::new("main")),
+        );
+        assert_eq!(text, "main");
+    }
+
+    #[test]
+    fn dispatch_duplicate_param_spans_param_id() {
+        let span_map = span_map_for(DISPATCH_YAML);
+        let text = dispatch_span_text(
+            DISPATCH_YAML,
+            &span_map,
+            &ResolveError::DuplicateParam(ParamId::new("my_param")),
+        );
+        assert_eq!(text, "my_param");
+    }
+
+    #[test]
+    fn dispatch_duplicate_material_spans_material_id() {
+        let span_map = span_map_for(DISPATCH_YAML);
+        let text = dispatch_span_text(
+            DISPATCH_YAML,
+            &span_map,
+            &ResolveError::DuplicateMaterial(MaterialId::new("my_material")),
+        );
+        assert_eq!(text, "my_material");
+    }
+
+    #[test]
+    fn dispatch_duplicate_act_spans_act_id() {
+        let span_map = span_map_for(DISPATCH_YAML);
+        let text = dispatch_span_text(
+            DISPATCH_YAML,
+            &span_map,
+            &ResolveError::DuplicateAct(ActId::new("setup")),
+        );
+        // Acts use node_to_span (the mapping node), not the id scalar — span has
+        // no length, so span_text returns "" but the diagnostic still has a span.
+        assert!(text.is_empty());
+    }
+
+    #[test]
+    fn dispatch_required_param_missing_spans_param_declaration() {
+        let span_map = span_map_for(DISPATCH_YAML);
+        let text = dispatch_span_text(
+            DISPATCH_YAML,
+            &span_map,
+            &ResolveError::RequiredParamMissing(ParamId::new("my_param")),
+        );
+        assert_eq!(text, "my_param");
+    }
+
+    #[test]
+    fn dispatch_param_type_mismatch_spans_param_declaration() {
+        let span_map = span_map_for(DISPATCH_YAML);
+        let text = dispatch_span_text(
+            DISPATCH_YAML,
+            &span_map,
+            &ResolveError::ParamTypeMismatch {
+                param: ParamId::new("my_param"),
+                expected: rite_model::ParameterType::Integer,
+                got: "string".to_string(),
+            },
+        );
+        assert_eq!(text, "my_param");
+    }
+
+    #[test]
+    fn dispatch_required_material_missing_spans_material_declaration() {
+        let span_map = span_map_for(DISPATCH_YAML);
+        let text = dispatch_span_text(
+            DISPATCH_YAML,
+            &span_map,
+            &ResolveError::RequiredMaterialMissing(MaterialId::new("my_material")),
+        );
+        assert_eq!(text, "my_material");
+    }
+
+    #[test]
+    fn dispatch_duplicate_output_spans_output_id() {
+        let span_map = span_map_for(DISPATCH_YAML);
+        let text = dispatch_span_text(
+            DISPATCH_YAML,
+            &span_map,
+            &ResolveError::DuplicateOutput(OutputId::new("signed_cert")),
+        );
+        assert_eq!(text, "signed_cert");
+    }
+
+    #[test]
+    fn dispatch_unused_output_warning_spans_output_declaration() {
+        let span_map = span_map_for(DISPATCH_YAML);
+        let text = dispatch_warning_span_text(
+            DISPATCH_YAML,
+            &span_map,
+            &ResolveWarning::UnusedOutput(OutputId::new("signed_cert")),
+        );
+        assert_eq!(text, "signed_cert");
+    }
+
+    #[test]
+    fn dispatch_artifact_not_output_warning_spans_creates_value() {
+        let span_map = span_map_for(DISPATCH_YAML);
+        let text = dispatch_warning_span_text(
+            DISPATCH_YAML,
+            &span_map,
+            &ResolveWarning::ArtifactNotOutput(ArtifactId::new("my_artifact")),
+        );
+        assert_eq!(text, "${artifact.my_artifact}");
     }
 }

--- a/crates/rite-resolver/src/lower.rs
+++ b/crates/rite-resolver/src/lower.rs
@@ -7,7 +7,7 @@ use crate::error::ResolveError;
 use crate::schema::Ceremony;
 use marked_yaml::Node;
 use marked_yaml::types::MarkedScalarNode;
-use rite_model::{ActId, MaterialId, ParamId, RoleId, SectionId, StepId};
+use rite_model::{ActId, ArtifactId, MaterialId, OutputId, ParamId, RoleId, SectionId, StepId};
 use std::path::Path;
 
 /// Parse ceremony YAML, build a `SpanMap`, and return structured diagnostics.
@@ -29,7 +29,7 @@ pub(crate) fn lower_ceremony(
     };
 
     // Step B: walk spans; always runs, even if Step C fails.
-    let (span_map, structural_diags) = walk_spans(path, &node);
+    let (span_map, structural_diags) = Lowerer::new(path, yaml).walk(&node);
     diags.extend(structural_diags);
 
     // Step C: serde deserialization from the same Node tree.
@@ -57,204 +57,364 @@ pub(crate) fn lower_ceremony(
     (ceremony_opt, span_map, diags)
 }
 
-/// Extract span information from all ceremony element IDs in the Node tree.
-#[allow(clippy::too_many_lines)]
-fn walk_spans(path: Option<&Path>, node: &Node) -> (SpanMap, Vec<Diagnostic>) {
-    const KNOWN_KEYS: &[&str] = &[
-        "version",
-        "name",
-        "description",
-        "backends",
-        "roles",
-        "acts",
-        "sections",
-        "parameters",
-        "materials",
-        "prerequisites",
-        "output",
-        "after",
-    ];
+/// Walks the YAML node tree once and accumulates the [`SpanMap`] used by the LSP
+/// to enrich diagnostics with source locations and to power go-to-definition.
+///
+/// Owning `yaml`, `path`, `span_map`, and `diags` together avoids the parameter
+/// sprawl that grows every time we add a new walked field.
+struct Lowerer<'src> {
+    yaml: &'src str,
+    path: Option<&'src Path>,
+    span_map: SpanMap,
+    diags: Vec<Diagnostic>,
+}
 
-    let mut span_map = SpanMap::default();
-    let mut diags = Vec::new();
+impl<'src> Lowerer<'src> {
+    fn new(path: Option<&'src Path>, yaml: &'src str) -> Self {
+        Self {
+            yaml,
+            path,
+            span_map: SpanMap::default(),
+            diags: Vec::new(),
+        }
+    }
 
-    let Some(mapping) = node.as_mapping() else {
-        return (span_map, diags);
-    };
+    #[allow(clippy::too_many_lines)]
+    fn walk(mut self, node: &Node) -> (SpanMap, Vec<Diagnostic>) {
+        const KNOWN_KEYS: &[&str] = &[
+            "version",
+            "name",
+            "description",
+            "backends",
+            "roles",
+            "acts",
+            "sections",
+            "parameters",
+            "materials",
+            "prerequisites",
+            "output",
+            "after",
+        ];
 
-    // Sections: mapping where keys are section IDs; each section contains nested steps.
-    if let Some(sections_map) = mapping.get_mapping("sections") {
-        for (section_id_scalar, section_node) in sections_map.iter() {
-            if let Some(span) = scalar_to_span(section_id_scalar) {
-                span_map
-                    .sections
-                    .insert(SectionId::new(section_id_scalar.as_str()), span);
-            }
+        let Some(mapping) = node.as_mapping() else {
+            return (self.span_map, self.diags);
+        };
 
-            let Some(section_map) = section_node.as_mapping() else {
-                continue;
-            };
+        // Sections: mapping where keys are section IDs; each section contains nested steps.
+        if let Some(sections_map) = mapping.get_mapping("sections") {
+            for (section_id_scalar, section_node) in sections_map.iter() {
+                if let Some(span) = self.scalar_to_span(section_id_scalar) {
+                    self.span_map
+                        .sections
+                        .insert(SectionId::new(section_id_scalar.as_str()), span);
+                }
 
-            // Collect section-level reference spans.
-            let section_context =
-                ReferenceContext::Section(SectionId::new(section_id_scalar.as_str()));
-            if let Some(val) = section_map.get_scalar("act") {
-                push_reference(
-                    &mut span_map,
-                    val,
-                    ReferenceTarget::Act(ActId::new(val.as_str())),
-                    &section_context,
-                );
-            }
-            if let Some(val) = section_map.get_scalar("role") {
-                push_reference(
-                    &mut span_map,
-                    val,
-                    ReferenceTarget::Role(RoleId::new(extract_role_id(val.as_str()))),
-                    &section_context,
-                );
-            }
-            if let Some(desc) = section_map.get_scalar("description") {
-                scan_expression_refs(&mut span_map, desc, &section_context);
-            }
+                let Some(section_map) = section_node.as_mapping() else {
+                    continue;
+                };
 
-            // Steps: mapping where keys are step IDs.
-            if let Some(steps_map) = section_map.get_mapping("steps") {
-                for (step_id_scalar, step_node) in steps_map.iter() {
-                    if let Some(span) = scalar_to_span(step_id_scalar) {
-                        span_map
-                            .steps
-                            .insert(StepId::new(step_id_scalar.as_str()), span);
+                let section_context =
+                    ReferenceContext::Section(SectionId::new(section_id_scalar.as_str()));
+                if let Some(val) = section_map.get_scalar("act") {
+                    self.push_reference(
+                        val,
+                        ReferenceTarget::Act(ActId::new(val.as_str())),
+                        &section_context,
+                    );
+                }
+                if let Some(val) = section_map.get_scalar("role") {
+                    self.push_reference(
+                        val,
+                        ReferenceTarget::Role(RoleId::new(extract_role_id(val.as_str()))),
+                        &section_context,
+                    );
+                }
+                if let Some(desc) = section_map.get_scalar("description") {
+                    self.scan_expression_refs(desc, &section_context);
+                }
+
+                if let Some(steps_map) = section_map.get_mapping("steps") {
+                    for (step_id_scalar, step_node) in steps_map.iter() {
+                        self.walk_step(step_id_scalar, step_node);
                     }
+                }
+            }
+        }
 
-                    let Some(step_map) = step_node.as_mapping() else {
-                        continue;
-                    };
+        // Roles: mapping where keys are role IDs.
+        if let Some(roles_map) = mapping.get_mapping("roles") {
+            for (key_scalar, _) in roles_map.iter() {
+                if let Some(span) = self.scalar_to_span(key_scalar) {
+                    self.span_map
+                        .roles
+                        .insert(RoleId::new(key_scalar.as_str()), span);
+                }
+            }
+        }
 
-                    // Validate required field.
-                    if !mapping_has_key(step_map, "action") {
-                        diags.push(Diagnostic {
-                            path: path.map(Path::to_owned),
-                            span: node_to_span(step_node),
+        // Acts: sequence of mappings, each with an "id" scalar.
+        if let Some(acts_seq) = mapping.get_sequence("acts") {
+            for act_node in acts_seq.iter() {
+                if let Some(act_map) = act_node.as_mapping() {
+                    if !mapping_has_key(act_map, "id") {
+                        self.diags.push(Diagnostic {
+                            path: self.path.map(Path::to_owned),
+                            span: node_to_span(act_node),
                             severity: Severity::Error,
-                            message: format!(
-                                "Step '{}' is missing required field 'action'",
-                                step_id_scalar.as_str()
-                            ),
+                            message: "Act is missing required field 'id'".to_string(),
                         });
                     }
+                    if let Some(id_scalar) = act_map.get_scalar("id")
+                        && let Some(span) = node_to_span(act_node)
+                    {
+                        self.span_map
+                            .acts
+                            .insert(ActId::new(id_scalar.as_str()), span);
+                    }
+                }
+            }
+        }
 
-                    // Collect step reference spans.
-                    let step_context = ReferenceContext::Step(StepId::new(step_id_scalar.as_str()));
-                    if let Some(val) = step_map.get_scalar("role") {
-                        push_reference(
-                            &mut span_map,
-                            val,
-                            ReferenceTarget::Role(RoleId::new(extract_role_id(val.as_str()))),
-                            &step_context,
-                        );
-                    }
-                    if let Some(val) = step_map.get_scalar("backend") {
-                        push_reference(
-                            &mut span_map,
-                            val,
-                            ReferenceTarget::Backend(val.as_str().to_string()),
-                            &step_context,
-                        );
-                    }
-                    if let Some(desc) = step_map.get_scalar("description") {
-                        scan_expression_refs(&mut span_map, desc, &step_context);
-                    }
-                    if let Some(with_map) = step_map.get_mapping("with") {
-                        for (_, val_node) in with_map.iter() {
-                            if let Some(scalar) = val_node.as_scalar() {
-                                scan_expression_refs(&mut span_map, scalar, &step_context);
-                            }
-                        }
-                    }
+        // Parameters: mapping where keys are param IDs.
+        if let Some(params_map) = mapping.get_mapping("parameters") {
+            for (key_scalar, _) in params_map.iter() {
+                if let Some(span) = self.scalar_to_span(key_scalar) {
+                    self.span_map
+                        .params
+                        .insert(ParamId::new(key_scalar.as_str()), span);
+                }
+            }
+        }
+
+        // Materials: mapping where keys are material IDs.
+        if let Some(materials_map) = mapping.get_mapping("materials") {
+            for (key_scalar, _) in materials_map.iter() {
+                if let Some(span) = self.scalar_to_span(key_scalar) {
+                    self.span_map
+                        .materials
+                        .insert(MaterialId::new(key_scalar.as_str()), span);
+                }
+            }
+        }
+
+        // Backends: mapping where keys are backend names.
+        if let Some(backends_map) = mapping.get_mapping("backends") {
+            for (key_scalar, _) in backends_map.iter() {
+                if let Some(span) = self.scalar_to_span(key_scalar) {
+                    self.span_map
+                        .backends
+                        .insert(key_scalar.as_str().to_string(), span);
+                }
+            }
+        }
+
+        // Outputs: mapping where keys are output IDs.
+        if let Some(outputs_map) = mapping.get_mapping("output") {
+            for (key_scalar, _) in outputs_map.iter() {
+                if let Some(span) = self.scalar_to_span(key_scalar) {
+                    self.span_map
+                        .outputs
+                        .insert(OutputId::new(key_scalar.as_str()), span);
+                }
+            }
+        }
+
+        // Unknown top-level key detection.
+        for (key_scalar, _) in mapping.iter() {
+            if !KNOWN_KEYS.contains(&key_scalar.as_str()) {
+                let span = self.scalar_to_span(key_scalar);
+                self.diags.push(Diagnostic {
+                    path: self.path.map(Path::to_owned),
+                    span,
+                    severity: Severity::Warning,
+                    message: format!("unknown top-level key: '{}'", key_scalar.as_str()),
+                });
+            }
+        }
+
+        (self.span_map, self.diags)
+    }
+
+    fn walk_step(&mut self, step_id_scalar: &MarkedScalarNode, step_node: &Node) {
+        if let Some(span) = self.scalar_to_span(step_id_scalar) {
+            self.span_map
+                .steps
+                .insert(StepId::new(step_id_scalar.as_str()), span);
+        }
+
+        let Some(step_map) = step_node.as_mapping() else {
+            return;
+        };
+
+        // Validate required field.
+        if !mapping_has_key(step_map, "action") {
+            let span = self.scalar_to_span(step_id_scalar);
+            self.diags.push(Diagnostic {
+                path: self.path.map(Path::to_owned),
+                span,
+                severity: Severity::Error,
+                message: format!(
+                    "Step '{}' is missing required field 'action'",
+                    step_id_scalar.as_str()
+                ),
+            });
+        }
+
+        let step_context = ReferenceContext::Step(StepId::new(step_id_scalar.as_str()));
+        if let Some(val) = step_map.get_scalar("role") {
+            self.push_reference(
+                val,
+                ReferenceTarget::Role(RoleId::new(extract_role_id(val.as_str()))),
+                &step_context,
+            );
+        }
+        if let Some(val) = step_map.get_scalar("backend") {
+            self.push_reference(
+                val,
+                ReferenceTarget::Backend(val.as_str().to_string()),
+                &step_context,
+            );
+        }
+        if let Some(val) = step_map.get_scalar("creates") {
+            let id = ArtifactId::new(extract_artifact_name(val.as_str()));
+            if let Some(span) = self.scalar_to_span(val) {
+                self.span_map.artifacts.insert(id.clone(), span);
+            }
+            self.push_reference(val, ReferenceTarget::Artifact(id), &step_context);
+        }
+        if let Some(reads_node) = step_map.get_node("reads") {
+            self.walk_reads(reads_node, &step_context);
+        }
+        if let Some(desc) = step_map.get_scalar("description") {
+            self.scan_expression_refs(desc, &step_context);
+        }
+        if let Some(with_map) = step_map.get_mapping("with") {
+            for (_, val_node) in with_map.iter() {
+                if let Some(scalar) = val_node.as_scalar() {
+                    self.scan_expression_refs(scalar, &step_context);
                 }
             }
         }
     }
 
-    // Roles: mapping where keys are role IDs.
-    if let Some(roles_map) = mapping.get_mapping("roles") {
-        for (key_scalar, _) in roles_map.iter() {
-            if let Some(span) = scalar_to_span(key_scalar) {
-                span_map
-                    .roles
-                    .insert(RoleId::new(key_scalar.as_str()), span);
-            }
-        }
-    }
-
-    // Acts: sequence of mappings, each with an "id" scalar.
-    if let Some(acts_seq) = mapping.get_sequence("acts") {
-        for act_node in acts_seq.iter() {
-            if let Some(act_map) = act_node.as_mapping() {
-                if !mapping_has_key(act_map, "id") {
-                    diags.push(Diagnostic {
-                        path: path.map(Path::to_owned),
-                        span: node_to_span(act_node),
-                        severity: Severity::Error,
-                        message: "Act is missing required field 'id'".to_string(),
-                    });
-                }
-                if let Some(id_scalar) = act_map.get_scalar("id")
-                    && let Some(span) = node_to_span(act_node)
-                {
-                    span_map.acts.insert(ActId::new(id_scalar.as_str()), span);
+    fn walk_reads(&mut self, reads_node: &Node, step_context: &ReferenceContext) {
+        if let Some(scalar) = reads_node.as_scalar() {
+            // Single artifact reference: `reads: "${artifact.x}"`.
+            let id = ArtifactId::new(extract_artifact_name(scalar.as_str()));
+            self.push_reference(scalar, ReferenceTarget::Artifact(id), step_context);
+        } else if let Some(reads_map) = reads_node.as_mapping() {
+            // Named inputs: `reads: { key_to_wrap: "...", wrapping_key: "..." }`.
+            for (_, val_node) in reads_map.iter() {
+                if let Some(scalar) = val_node.as_scalar() {
+                    let id = ArtifactId::new(extract_artifact_name(scalar.as_str()));
+                    self.push_reference(scalar, ReferenceTarget::Artifact(id), step_context);
                 }
             }
         }
     }
 
-    // Parameters: mapping where keys are param IDs.
-    if let Some(params_map) = mapping.get_mapping("parameters") {
-        for (key_scalar, _) in params_map.iter() {
-            if let Some(span) = scalar_to_span(key_scalar) {
-                span_map
-                    .params
-                    .insert(ParamId::new(key_scalar.as_str()), span);
+    /// Scan a scalar value for `${prefix.NAME}` expression references and push a
+    /// `ReferenceEntry` for each recognized prefix.
+    ///
+    /// `material` is handled here even though it is not a `RefType` in the model
+    /// (it resolves as an artifact at the IR level): the LSP needs to navigate
+    /// from `${material.x}` to the material declaration. Nested property paths
+    /// like `${artifact.keypair.private}` are intentionally skipped — handle
+    /// them at the expression-parser level when richer go-to-definition is needed.
+    #[allow(clippy::arithmetic_side_effects)]
+    fn scan_expression_refs(&mut self, scalar: &MarkedScalarNode, context: &ReferenceContext) {
+        let Some(base) = self.scalar_to_span(scalar) else {
+            return;
+        };
+        let text = scalar.as_str();
+        let mut search_from = 0;
+        while let Some(rel_start) = text.get(search_from..).and_then(|s| s.find("${")) {
+            let abs_start = search_from + rel_start;
+            let after_open = abs_start + 2; // skip "${"
+            let Some(close_offset) = text.get(after_open..).and_then(|s| s.find('}')) else {
+                break;
+            };
+            let Some(expr_content) = text.get(after_open..after_open + close_offset) else {
+                break;
+            };
+            let full_len = 2 + close_offset + 1; // "${" + content + "}"
+
+            if let Some(dot_pos) = expr_content.find('.') {
+                let prefix = &expr_content[..dot_pos];
+                let name = &expr_content[dot_pos + 1..];
+                if !name.is_empty() && !name.contains('.') {
+                    let target = match prefix {
+                        "param" => Some(ReferenceTarget::Param(ParamId::new(name))),
+                        "material" => Some(ReferenceTarget::Material(MaterialId::new(name))),
+                        "artifact" => Some(ReferenceTarget::Artifact(ArtifactId::new(name))),
+                        "role" => Some(ReferenceTarget::Role(RoleId::new(name))),
+                        _ => None,
+                    };
+                    if let Some(target) = target {
+                        let value = text
+                            .get(abs_start..abs_start + full_len)
+                            .unwrap_or("")
+                            .to_string();
+                        self.span_map.references.push(ReferenceEntry {
+                            span: Span {
+                                line: base.line,
+                                column: base.column + abs_start,
+                                length: Some(full_len),
+                            },
+                            target,
+                            context: context.clone(),
+                            value,
+                        });
+                    }
+                }
             }
+            search_from = abs_start + full_len;
         }
     }
 
-    // Materials: mapping where keys are material IDs.
-    if let Some(materials_map) = mapping.get_mapping("materials") {
-        for (key_scalar, _) in materials_map.iter() {
-            if let Some(span) = scalar_to_span(key_scalar) {
-                span_map
-                    .materials
-                    .insert(MaterialId::new(key_scalar.as_str()), span);
-            }
-        }
-    }
-
-    // Backends: mapping where keys are backend names.
-    if let Some(backends_map) = mapping.get_mapping("backends") {
-        for (key_scalar, _) in backends_map.iter() {
-            if let Some(span) = scalar_to_span(key_scalar) {
-                span_map
-                    .backends
-                    .insert(key_scalar.as_str().to_string(), span);
-            }
-        }
-    }
-
-    // Unknown top-level key detection.
-    for (key_scalar, _) in mapping.iter() {
-        if !KNOWN_KEYS.contains(&key_scalar.as_str()) {
-            diags.push(Diagnostic {
-                path: path.map(Path::to_owned),
-                span: scalar_to_span(key_scalar),
-                severity: Severity::Warning,
-                message: format!("unknown top-level key: '{}'", key_scalar.as_str()),
+    /// Push a reference entry for a scalar value node (for fields like `role:`,
+    /// `backend:`, `act:`, `creates:`, `reads:`).
+    fn push_reference(
+        &mut self,
+        val: &MarkedScalarNode,
+        target: ReferenceTarget,
+        context: &ReferenceContext,
+    ) {
+        if let Some(span) = self.scalar_to_span(val) {
+            self.span_map.references.push(ReferenceEntry {
+                span,
+                target,
+                context: context.clone(),
+                value: val.as_str().to_string(),
             });
         }
     }
 
-    (span_map, diags)
+    /// Build a `Span` for a scalar value, with column at the first content character
+    /// and length covering the scalar text.
+    ///
+    /// For quoted scalars `marked_yaml` places the START marker at the opening quote,
+    /// but `scalar.as_str()` returns the content without the quotes — so we shift the
+    /// column by 1 when the source byte is `"` or `'`. This keeps byte offsets within
+    /// `as_str()` aligned with source characters for both quoted and unquoted scalars.
+    fn scalar_to_span(&self, scalar: &MarkedScalarNode) -> Option<Span> {
+        let m = scalar.span().start()?;
+        let is_quoted = self
+            .yaml
+            .as_bytes()
+            .get(m.character())
+            .is_some_and(|&b| b == b'"' || b == b'\'');
+        let column = if is_quoted {
+            m.column().saturating_add(1)
+        } else {
+            m.column()
+        };
+        Some(Span {
+            line: m.line(),
+            column,
+            length: Some(scalar.as_str().len()),
+        })
+    }
 }
 
 /// Check whether a mapping node contains a key with the given name (any value type).
@@ -269,94 +429,15 @@ fn extract_role_id(raw: &str) -> &str {
         .unwrap_or(raw)
 }
 
-/// Scan a scalar value for `${param.X}` and `${material.X}` expression references.
-///
-/// For each match, a `ReferenceEntry` is pushed into `span_map.references` with the
-/// span pointing at the `$` of the expression and `value_len` covering the full `${...}`.
-/// This enables go-to-definition when the cursor is anywhere within an expression.
-///
-/// Uses simple string scanning rather than the expression parser because `material`
-/// is not a valid `RefType` in the expression model; it is resolved as an artifact
-/// at the IR level. The LSP needs to navigate from `${material.x}` to the material
-/// declaration, so we handle it at the raw string level here.
-#[allow(clippy::arithmetic_side_effects)]
-fn scan_expression_refs(
-    span_map: &mut SpanMap,
-    scalar: &MarkedScalarNode,
-    context: &ReferenceContext,
-) {
-    let Some(base_span) = scalar_to_span(scalar) else {
-        return;
-    };
-    let text = scalar.as_str();
-    let mut search_from = 0;
-    while let Some(rel_start) = text.get(search_from..).and_then(|s| s.find("${")) {
-        let abs_start = search_from + rel_start;
-        let after_open = abs_start + 2; // skip "${"
-        let Some(close_offset) = text.get(after_open..).and_then(|s| s.find('}')) else {
-            break;
-        };
-        let Some(expr_content) = text.get(after_open..after_open + close_offset) else {
-            break;
-        };
-        let full_len = 2 + close_offset + 1; // "${" + content + "}"
-
-        if let Some(dot_pos) = expr_content.find('.') {
-            let prefix = &expr_content[..dot_pos];
-            let name = &expr_content[dot_pos + 1..];
-            // Only handle simple names (no nested dots like artifact.keypair.private).
-            if !name.is_empty() && !name.contains('.') {
-                let target = match prefix {
-                    "param" => Some(ReferenceTarget::Param(ParamId::new(name))),
-                    "material" => Some(ReferenceTarget::Material(MaterialId::new(name))),
-                    _ => None,
-                };
-                if let Some(target) = target {
-                    // Column is 1-indexed; abs_start is a byte offset from scalar start.
-                    let col = base_span.column + abs_start;
-                    span_map.references.push(ReferenceEntry {
-                        span: Span {
-                            line: base_span.line,
-                            column: col,
-                            length: Some(full_len),
-                        },
-                        target,
-                        context: context.clone(),
-                    });
-                }
-            }
-        }
-        search_from = abs_start + full_len;
-    }
-}
-
-/// Push a reference entry into `span_map.references` for the given scalar value node.
-fn push_reference(
-    span_map: &mut SpanMap,
-    val: &MarkedScalarNode,
-    target: ReferenceTarget,
-    context: &ReferenceContext,
-) {
-    if let Some(mut span) = scalar_to_span(val) {
-        span.length = Some(val.as_str().len());
-        span_map.references.push(ReferenceEntry {
-            span,
-            target,
-            context: context.clone(),
-        });
-    }
+/// Extract a plain artifact name from either `"${artifact.name}"` syntax or a bare name.
+fn extract_artifact_name(raw: &str) -> &str {
+    raw.strip_prefix("${artifact.")
+        .and_then(|s| s.strip_suffix('}'))
+        .unwrap_or(raw)
 }
 
 fn node_to_span(node: &Node) -> Option<Span> {
     node.span().start().map(|m| Span {
-        line: m.line(),
-        column: m.column(),
-        length: None,
-    })
-}
-
-fn scalar_to_span(scalar: &MarkedScalarNode) -> Option<Span> {
-    scalar.span().start().map(|m| Span {
         line: m.line(),
         column: m.column(),
         length: None,
@@ -469,6 +550,391 @@ pub(crate) fn diagnostic_to_resolve_error(d: Diagnostic) -> ResolveError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_helpers::{annotate, span_text};
+
+    #[test]
+    fn declaration_spans_cover_full_identifier() {
+        // This test verifies that every declaration span carries the token length so
+        // that editors underline the full identifier, not just the first character.
+        let yaml = r#"
+version: "0.2"
+name: "Test"
+roles:
+  alice: {}
+parameters:
+  my_param:
+    type: text
+sections:
+  main:
+    steps:
+      my_step:
+        action: confirm
+"#;
+        let (_, span_map, _) = lower_ceremony(None, yaml);
+
+        let alice = *span_map
+            .roles
+            .get(&RoleId::new("alice"))
+            .expect("alice role span");
+        assert_eq!(
+            annotate(yaml, alice),
+            "  alice: {}\n  ^^^^^",
+            "role span must cover the full identifier"
+        );
+
+        let my_param = *span_map
+            .params
+            .get(&ParamId::new("my_param"))
+            .expect("my_param span");
+        assert_eq!(
+            annotate(yaml, my_param),
+            "  my_param:\n  ^^^^^^^^",
+            "parameter span must cover the full identifier"
+        );
+
+        let main = *span_map
+            .sections
+            .get(&SectionId::new("main"))
+            .expect("main section span");
+        assert_eq!(
+            annotate(yaml, main),
+            "  main:\n  ^^^^",
+            "section span must cover the full identifier"
+        );
+
+        let my_step = *span_map
+            .steps
+            .get(&StepId::new("my_step"))
+            .expect("my_step span");
+        assert_eq!(
+            annotate(yaml, my_step),
+            "      my_step:\n      ^^^^^^^",
+            "step span must cover the full identifier"
+        );
+    }
+
+    #[test]
+    fn unknown_top_level_key_warning_covers_full_key() {
+        let yaml = r#"
+version: "0.2"
+name: "Test"
+roles: {}
+sections: {}
+unknown_key: value
+"#;
+        let (_, _, diags) = lower_ceremony(None, yaml);
+        let warning = diags
+            .iter()
+            .find(|d| d.message.contains("unknown_key"))
+            .expect("should have unknown key warning");
+        let span = warning.span.expect("warning must have a span");
+        assert_eq!(
+            annotate(yaml, span),
+            "unknown_key: value\n^^^^^^^^^^^",
+            "unknown key warning must cover the full key name"
+        );
+    }
+
+    #[test]
+    fn expression_param_ref_span_covers_full_expression() {
+        let yaml = r#"
+version: "0.2"
+name: "Test"
+roles: {}
+parameters:
+  x:
+    type: text
+sections:
+  main:
+    steps:
+      my_step:
+        action: confirm
+        description: "${param.x}"
+"#;
+        let (_, span_map, _) = lower_ceremony(None, yaml);
+
+        let entry = span_map
+            .references
+            .iter()
+            .find(|e| matches!(&e.target, ReferenceTarget::Param(id) if id.as_str() == "x"))
+            .expect("should have a reference entry for param 'x'");
+
+        assert_eq!(
+            span_text(yaml, entry.span),
+            "${param.x}",
+            "expression span must cover the full ${{...}} token"
+        );
+        assert_eq!(entry.span.length, Some(10));
+    }
+
+    #[test]
+    fn material_declaration_span_covers_full_identifier() {
+        let yaml = r#"
+version: "0.2"
+name: "Test"
+roles: {}
+sections: {}
+materials:
+  my_material:
+    type: digital
+"#;
+        let (_, span_map, _) = lower_ceremony(None, yaml);
+        let span = *span_map
+            .materials
+            .get(&MaterialId::new("my_material"))
+            .expect("my_material span");
+        assert_eq!(
+            annotate(yaml, span),
+            "  my_material:\n  ^^^^^^^^^^^",
+            "material span must cover the full identifier"
+        );
+    }
+
+    #[test]
+    fn backend_declaration_span_covers_full_identifier() {
+        let yaml = r#"
+version: "0.2"
+name: "Test"
+roles: {}
+sections: {}
+backends:
+  ssl:
+    provider: openssl
+"#;
+        let (_, span_map, _) = lower_ceremony(None, yaml);
+        let span = *span_map.backends.get("ssl").expect("ssl backend span");
+        assert_eq!(
+            annotate(yaml, span),
+            "  ssl:\n  ^^^",
+            "backend span must cover the full identifier"
+        );
+    }
+
+    #[test]
+    fn output_declaration_span_covers_full_identifier() {
+        let yaml = r#"
+version: "0.2"
+name: "Test"
+roles: {}
+sections: {}
+output:
+  signed_cert:
+    type: artifact
+"#;
+        let (_, span_map, _) = lower_ceremony(None, yaml);
+        let span = *span_map
+            .outputs
+            .get(&OutputId::new("signed_cert"))
+            .expect("signed_cert output span");
+        assert_eq!(
+            annotate(yaml, span),
+            "  signed_cert:\n  ^^^^^^^^^^^",
+            "output span must cover the full identifier"
+        );
+    }
+
+    #[test]
+    fn quoted_declaration_key_span_skips_opening_quote() {
+        // Regression: quoted YAML keys used to mis-report column at the `"`,
+        // making the underlined slice include the opening quote and miss the
+        // last character of the identifier.
+        let yaml = "
+version: \"0.2\"
+name: \"Test\"
+roles:
+  \"alice\": {}
+sections: {}
+";
+        let (_, span_map, _) = lower_ceremony(None, yaml);
+        let span = *span_map
+            .roles
+            .get(&RoleId::new("alice"))
+            .expect("alice role span");
+        assert_eq!(
+            span_text(yaml, span),
+            "alice",
+            "quoted role key span must underline the identifier, not the opening quote"
+        );
+    }
+
+    #[test]
+    fn role_field_unquoted_value_records_reference_with_full_span() {
+        let yaml = r#"
+version: "0.2"
+name: "Test"
+roles:
+  alice: {}
+sections:
+  main:
+    steps:
+      my_step:
+        action: confirm
+        role: "${role.alice}"
+"#;
+        let (_, span_map, _) = lower_ceremony(None, yaml);
+        let entry = span_map
+            .references
+            .iter()
+            .find(|e| matches!(&e.target, ReferenceTarget::Role(id) if id.as_str() == "alice"))
+            .expect("should have a Role reference for alice");
+        assert_eq!(span_text(yaml, entry.span), "${role.alice}");
+        assert_eq!(entry.value, "${role.alice}");
+    }
+
+    #[test]
+    fn material_expression_ref_span_covers_full_token() {
+        let yaml = r#"
+version: "0.2"
+name: "Test"
+roles: {}
+materials:
+  my_material:
+    type: digital
+sections:
+  main:
+    steps:
+      my_step:
+        action: confirm
+        description: "see ${material.my_material} for details"
+"#;
+        let (_, span_map, _) = lower_ceremony(None, yaml);
+        let entry = span_map
+            .references
+            .iter()
+            .find(
+                |e| matches!(&e.target, ReferenceTarget::Material(id) if id.as_str() == "my_material"),
+            )
+            .expect("should have a Material reference entry");
+        assert_eq!(span_text(yaml, entry.span), "${material.my_material}");
+    }
+
+    #[test]
+    fn unterminated_expression_does_not_panic() {
+        let yaml = r#"
+version: "0.2"
+name: "Test"
+roles: {}
+sections:
+  main:
+    steps:
+      my_step:
+        action: confirm
+        description: "${param.x"
+"#;
+        let (_, span_map, _) = lower_ceremony(None, yaml);
+        assert!(
+            !span_map
+                .references
+                .iter()
+                .any(|e| matches!(e.target, ReferenceTarget::Param(_))),
+            "unterminated expression must not produce a reference entry"
+        );
+    }
+
+    #[test]
+    fn creates_field_records_artifact_reference_and_artifact_span() {
+        let yaml = r#"
+version: "0.2"
+name: "Test"
+roles: {}
+sections:
+  main:
+    steps:
+      gen_step:
+        action: confirm
+        creates: "${artifact.keypair}"
+"#;
+        let (_, span_map, _) = lower_ceremony(None, yaml);
+
+        // Reference entry recorded against the step.
+        let entry = span_map
+            .references
+            .iter()
+            .find(
+                |e| matches!(&e.target, ReferenceTarget::Artifact(id) if id.as_str() == "keypair"),
+            )
+            .expect("should have an Artifact reference for keypair");
+        assert_eq!(span_text(yaml, entry.span), "${artifact.keypair}");
+
+        // Artifact span is recorded so `ArtifactNotOutput` warnings can underline it.
+        let artifact_span = *span_map
+            .artifacts
+            .get(&ArtifactId::new("keypair"))
+            .expect("keypair artifact span");
+        assert_eq!(span_text(yaml, artifact_span), "${artifact.keypair}");
+    }
+
+    #[test]
+    fn reads_named_inputs_record_artifact_references() {
+        let yaml = r#"
+version: "0.2"
+name: "Test"
+roles: {}
+sections:
+  main:
+    steps:
+      use_step:
+        action: confirm
+        reads:
+          first: "${artifact.alpha}"
+          second: "${artifact.beta}"
+"#;
+        let (_, span_map, _) = lower_ceremony(None, yaml);
+        let names: Vec<&str> = span_map
+            .references
+            .iter()
+            .filter_map(|e| match &e.target {
+                ReferenceTarget::Artifact(id) => Some(id.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(names.contains(&"alpha"));
+        assert!(names.contains(&"beta"));
+    }
+
+    #[test]
+    fn reads_string_form_records_artifact_reference() {
+        let yaml = r#"
+version: "0.2"
+name: "Test"
+roles: {}
+sections:
+  main:
+    steps:
+      use_step:
+        action: confirm
+        reads: "${artifact.alpha}"
+"#;
+        let (_, span_map, _) = lower_ceremony(None, yaml);
+        let entry = span_map
+            .references
+            .iter()
+            .find(|e| matches!(&e.target, ReferenceTarget::Artifact(id) if id.as_str() == "alpha"))
+            .expect("should record a single artifact reference for string-form reads");
+        assert_eq!(span_text(yaml, entry.span), "${artifact.alpha}");
+    }
+
+    #[test]
+    fn expression_artifact_ref_in_description_is_recorded() {
+        let yaml = r#"
+version: "0.2"
+name: "Test"
+roles: {}
+sections:
+  main:
+    steps:
+      my_step:
+        action: confirm
+        description: "uses ${artifact.foo}"
+"#;
+        let (_, span_map, _) = lower_ceremony(None, yaml);
+        let entry = span_map
+            .references
+            .iter()
+            .find(|e| matches!(&e.target, ReferenceTarget::Artifact(id) if id.as_str() == "foo"))
+            .expect("scan_expression_refs must now handle the `artifact` prefix");
+        assert_eq!(span_text(yaml, entry.span), "${artifact.foo}");
+    }
 
     const MINIMAL_CEREMONY: &str = r#"
 version: "0.2"

--- a/crates/rite-resolver/src/resolve.rs
+++ b/crates/rite-resolver/src/resolve.rs
@@ -586,6 +586,7 @@ impl ResolveContext {
                     field: "role".to_string(),
                     expected: RefType::Role,
                     actual: reference.ref_type,
+                    value: role_ref.to_string(),
                 });
                 return None;
             }
@@ -674,6 +675,7 @@ impl ResolveContext {
                 field: field.to_string(),
                 expected: RefType::Artifact,
                 actual: reference.ref_type,
+                value: ref_str.to_string(),
             });
             return None;
         }

--- a/crates/rite-resolver/src/test_helpers.rs
+++ b/crates/rite-resolver/src/test_helpers.rs
@@ -1,0 +1,23 @@
+//! Visual span assertion helpers shared by test modules.
+//!
+//! `span_text` extracts the exact characters a span covers; `annotate` renders
+//! a two-line caret diagram. Use them so assertions read like
+//! `assert_eq!(span_text(yaml, span), "${role.ghost}")` rather than asserting
+//! line/column/length numbers.
+
+use crate::diagnostic::Span;
+
+#[allow(clippy::arithmetic_side_effects)]
+pub(crate) fn span_text(yaml: &str, span: Span) -> &str {
+    let line = yaml.lines().nth(span.line.saturating_sub(1)).unwrap_or("");
+    let start = span.column.saturating_sub(1);
+    let end = start + span.length.unwrap_or(0);
+    line.get(start..end).unwrap_or("")
+}
+
+pub(crate) fn annotate(yaml: &str, span: Span) -> String {
+    let line = yaml.lines().nth(span.line.saturating_sub(1)).unwrap_or("");
+    let col0 = span.column.saturating_sub(1);
+    let carets = span.length.unwrap_or(0).max(1);
+    format!("{}\n{}{}", line, " ".repeat(col0), "^".repeat(carets))
+}


### PR DESCRIPTION
- Span-accuracy fixes: declarations carry length; quoted YAML scalars use the content column (not the opening quote); `InvalidReferenceSyntax` /  `ReferenceTypeMismatch` underline the bad value instead of the enclosing step
- Walk `output:`, `creates:`, and `reads:` so `DuplicateOutput`, `UnusedOutput`, `ArtifactNotOutput`, and artifact-typed errors all get precise spans
- Extend `${...}` expression scan to handle `artifact` and `role` prefixes (was: `param` / `material` only)
- Refactor `walk_spans` into a `Lowerer<'src>` struct — no behavior change; eliminates `yaml: &str` parameter sprawl
- Lift `declaration_span` / `declaration_target_for_word` / `references_for_target` onto `SpanMap` so `rite-ls` (and any future tool) share one navigation API; LSP modules become thin callers
- Add `Artifact` variant to `ReferenceTarget`; artifact hover distinguishes "produced upstream" from material-backed. 
