### PR TITLE
fix(build): Stamp real commit SHA into docker-built binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.check.outputs.version }}
+      commit_sha: ${{ steps.commit.outputs.sha }}
+      commit_date: ${{ steps.commit.outputs.date }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check tag matches workspace version
@@ -30,6 +32,12 @@ jobs:
             exit 1
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+      - name: Resolve commit metadata
+        id: commit
+        # Stamped into every binary (native + docker) via RITE_BUILD_COMMIT /
+        # RITE_BUILD_COMMIT_DATE so all artefacts for this release report the
+        # same commit format. Short SHA via %h; date via %cd --date=short.
+        run: git log -1 --format='sha=%h%ndate=%cd' --date=short >> "$GITHUB_OUTPUT"
 
   build-native:
     name: Build (${{ matrix.rite_target }})
@@ -38,6 +46,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    env:
+      RITE_BUILD_COMMIT: ${{ needs.validate.outputs.commit_sha }}
+      RITE_BUILD_COMMIT_DATE: ${{ needs.validate.outputs.commit_date }}
     strategy:
       fail-fast: false
       matrix:
@@ -129,6 +140,9 @@ jobs:
 
       - name: Bake binaries + image
         uses: docker/bake-action@a66e1c87e2eca0503c343edf1d208c716d54b8a8 # v7.1.0
+        env:
+          RITE_BUILD_COMMIT: ${{ needs.validate.outputs.commit_sha }}
+          RITE_BUILD_COMMIT_DATE: ${{ needs.validate.outputs.commit_date }}
         with:
           files: |
             ./docker-bake.hcl

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,27 @@
 # to QEMU emulation for the C compile steps.
 ARG TOOLCHAIN_PLATFORM=linux/amd64
 
+# Build context has no .git/, so rite-cli's build.rs records "unknown" for the
+# commit unless these are injected. Defaults make local `docker build` work
+# without ceremony; CI passes the real SHA and date via bake.
+ARG RITE_BUILD_COMMIT=unknown
+ARG RITE_BUILD_COMMIT_DATE=unknown
+
 FROM --platform=${TOOLCHAIN_PLATFORM} ghcr.io/rust-cross/rust-musl-cross:x86_64-musl@sha256:6c3c52df33dbd3fa999455c56db5be6fe2a9df5af63e00388194d936fd5cd003 AS builder-amd64
 WORKDIR /src
 ARG CARGO_BUILD_ARGS="--features openssl-vendored"
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
+# Commit ARGs declared at the RUN to keep the COPY layer cache-stable across
+# commits; only the cargo build layer invalidates (and cargo's target cache
+# mount keeps the incremental rebuild tiny, just rite-cli's final link).
 # Per-target cache IDs so the two builder stages can run in parallel under bake without racing.
+ARG RITE_BUILD_COMMIT
+ARG RITE_BUILD_COMMIT_DATE
 RUN --mount=type=cache,target=/root/.cargo/registry,id=cargo-registry-amd64 \
     --mount=type=cache,target=/src/target,id=cargo-target-amd64 \
+    RITE_BUILD_COMMIT="$RITE_BUILD_COMMIT" \
+    RITE_BUILD_COMMIT_DATE="$RITE_BUILD_COMMIT_DATE" \
     cargo build --locked --release -p rite-cli $CARGO_BUILD_ARGS && \
     cargo build --locked --release -p rite-ls && \
     install -D -m 0755 target/x86_64-unknown-linux-musl/release/rite    /out/rite && \
@@ -30,8 +43,12 @@ WORKDIR /src
 ARG CARGO_BUILD_ARGS="--features openssl-vendored"
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
+ARG RITE_BUILD_COMMIT
+ARG RITE_BUILD_COMMIT_DATE
 RUN --mount=type=cache,target=/root/.cargo/registry,id=cargo-registry-arm64 \
     --mount=type=cache,target=/src/target,id=cargo-target-arm64 \
+    RITE_BUILD_COMMIT="$RITE_BUILD_COMMIT" \
+    RITE_BUILD_COMMIT_DATE="$RITE_BUILD_COMMIT_DATE" \
     cargo build --locked --release -p rite-cli $CARGO_BUILD_ARGS && \
     cargo build --locked --release -p rite-ls && \
     install -D -m 0755 target/aarch64-unknown-linux-musl/release/rite    /out/rite && \

--- a/crates/rite-cli/build.rs
+++ b/crates/rite-cli/build.rs
@@ -1,8 +1,15 @@
 use chrono::Utc;
 use std::process::Command;
 
+const UNKNOWN: &str = "unknown";
+
 fn main() {
-    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    // RITE_BUILD_COMMIT and RITE_BUILD_COMMIT_DATE are computed once by the
+    // release pipeline (.github/workflows/release.yml) and exported as job-level
+    // env vars to every builder (native + docker). Local builds without them
+    // get "unknown".
+    println!("cargo:rerun-if-env-changed=RITE_BUILD_COMMIT");
+    println!("cargo:rerun-if-env-changed=RITE_BUILD_COMMIT_DATE");
 
     let target = var("TARGET");
     let profile = var("PROFILE");
@@ -10,9 +17,14 @@ fn main() {
     println!("cargo:rustc-env=RITE_BUILD_TARGET={target}");
     println!("cargo:rustc-env=RITE_BUILD_PROFILE={profile}");
     println!("cargo:rustc-env=RITE_BUILD_FEATURES={}", features());
-    let (commit, commit_date) = git_info();
-    println!("cargo:rustc-env=RITE_BUILD_COMMIT={commit}");
-    println!("cargo:rustc-env=RITE_BUILD_COMMIT_DATE={commit_date}");
+    println!(
+        "cargo:rustc-env=RITE_BUILD_COMMIT={}",
+        var("RITE_BUILD_COMMIT")
+    );
+    println!(
+        "cargo:rustc-env=RITE_BUILD_COMMIT_DATE={}",
+        var("RITE_BUILD_COMMIT_DATE")
+    );
     println!(
         "cargo:rustc-env=RITE_BUILD_DATE={}",
         Utc::now().format("%Y-%m-%d")
@@ -21,7 +33,7 @@ fn main() {
 }
 
 fn var(name: &str) -> String {
-    std::env::var(name).unwrap_or_else(|_| "unknown".to_string())
+    std::env::var(name).unwrap_or_else(|_| UNKNOWN.to_string())
 }
 
 fn features() -> String {
@@ -52,25 +64,10 @@ fn cmd_output(program: &str, args: &[&str]) -> Option<String> {
         .and_then(|o| String::from_utf8(o.stdout).ok())
 }
 
-fn trimmed(s: Option<&str>) -> String {
-    s.map(str::trim)
-        .filter(|s| !s.is_empty())
-        .unwrap_or("unknown")
-        .to_string()
-}
-
-fn git_info() -> (String, String) {
-    let Some(out) = cmd_output("git", &["log", "-1", "--format=%h%n%cd", "--date=short"]) else {
-        return ("unknown".to_string(), "unknown".to_string());
-    };
-    let mut lines = out.lines();
-    (trimmed(lines.next()), trimmed(lines.next()))
-}
-
 fn rustc_version() -> String {
     cmd_output("rustc", &["--version"])
         .as_deref()
         .and_then(|s| s.trim().strip_prefix("rustc "))
-        .unwrap_or("unknown")
+        .unwrap_or(UNKNOWN)
         .to_string()
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -16,6 +16,17 @@
 #
 # CI injects tags and cache scopes via `--set` on the bake-action.
 
+# Commit metadata stamped into the binaries via build args. Set RITE_BUILD_COMMIT
+# and RITE_BUILD_COMMIT_DATE in the environment (CI does this) or via `--set`.
+# Defaults to "unknown" so local `docker buildx bake` works without ceremony.
+variable "RITE_BUILD_COMMIT" {
+  default = "unknown"
+}
+
+variable "RITE_BUILD_COMMIT_DATE" {
+  default = "unknown"
+}
+
 group "default" {
   targets = ["binaries-amd64", "binaries-arm64", "image"]
 }
@@ -27,11 +38,19 @@ group "binaries" {
 target "binaries-amd64" {
   target = "binaries-amd64"
   output = ["type=local,dest=dist/amd64"]
+  args = {
+    RITE_BUILD_COMMIT      = RITE_BUILD_COMMIT
+    RITE_BUILD_COMMIT_DATE = RITE_BUILD_COMMIT_DATE
+  }
 }
 
 target "binaries-arm64" {
   target = "binaries-arm64"
   output = ["type=local,dest=dist/arm64"]
+  args = {
+    RITE_BUILD_COMMIT      = RITE_BUILD_COMMIT
+    RITE_BUILD_COMMIT_DATE = RITE_BUILD_COMMIT_DATE
+  }
 }
 
 target "image" {
@@ -41,6 +60,10 @@ target "image" {
     "type=sbom",
     "type=provenance,mode=max,version=v1",
   ]
+  args = {
+    RITE_BUILD_COMMIT      = RITE_BUILD_COMMIT
+    RITE_BUILD_COMMIT_DATE = RITE_BUILD_COMMIT_DATE
+  }
   # output / tags injected by CI: `--set image.output=type=registry,push=true`,
   # tags via the bake file produced by docker/metadata-action.
 }


### PR DESCRIPTION
 The docker builder stage copies only Cargo.toml, Cargo.lock and crates/ into the build context, so build.rs cannot run `git log` and was recording "unknown" for RITE_BUILD_COMMIT / RITE_BUILD_COMMIT_DATE. Native macOS/Windows builds were fine because the runner had a real .git/ checkout.

Compute the values once in the validate job, expose them as outputs, and inject into every builder: native via a job-level env block, docker via a bake variable to a Dockerfile ARG to an inline env on the cargo build RUN. build.rs becomes a plain env read with "unknown" fallback for local cargo builds.
