### PR TITLE
feat(tui): add a System information tab to the TUI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ ratatui = { version = "0.30.0", default-features = false, features = [
 crossterm = "0.29.0"
 dashmap = "6.1.0"
 subtle = "2.6.1"
-sysinfo = { version = "0.39.0", default-features = false, features = ["system"] }
+sysinfo = { version = "0.39.0", default-features = false, features = ["system", "disk"] }
 x509-cert = "0.2.5"
 der = "0.7.10"
 sha2 = "0.11.0"

--- a/crates/rite-cli/src/headless.rs
+++ b/crates/rite-cli/src/headless.rs
@@ -104,7 +104,10 @@ fn render_fact<W: Write>(out: &mut W, fact: &StepFact) -> io::Result<()> {
 fn render_signal<W: Write>(out: &mut W, signal: &UiSignal) -> io::Result<()> {
     match signal {
         UiSignal::LogLine { text, .. } => writeln!(out, "  {text}"),
-        UiSignal::Progress { .. } | UiSignal::CeremonyOverview { .. } => Ok(()),
+        UiSignal::Progress { .. }
+        | UiSignal::CeremonyOverview { .. }
+        | UiSignal::SystemInfo(_)
+        | UiSignal::Environment(_) => Ok(()),
     }
 }
 

--- a/crates/rite-cli/src/main.rs
+++ b/crates/rite-cli/src/main.rs
@@ -11,6 +11,7 @@ mod report;
 mod run;
 #[cfg(feature = "render")]
 mod script;
+mod system_info;
 mod verify;
 mod version;
 

--- a/crates/rite-cli/src/run.rs
+++ b/crates/rite-cli/src/run.rs
@@ -5,7 +5,9 @@ use std::path::PathBuf;
 use clap::{Args as ClapArgs, ValueEnum};
 use crossbeam_channel::unbounded;
 
-use rite_runtime::{ExecEvent, Executor, InMemorySink, JsonlFileSink, TranscriptSink, UiCommand};
+use rite_runtime::{
+    ExecEvent, Executor, InMemorySink, JsonlFileSink, StartupSnapshot, TranscriptSink, UiCommand,
+};
 
 use crate::common::{
     InputArgs, build_inputs_or_exit, preflight_check_materials, prompt_missing_params,
@@ -110,12 +112,18 @@ pub fn run(args: Args) {
     let (cmd_tx, cmd_rx) = unbounded::<UiCommand>();
     let (event_tx, event_rx) = unbounded::<ExecEvent>();
 
+    let startup = StartupSnapshot {
+        system: crate::system_info::gather_system(),
+        environment: crate::system_info::gather_environment(),
+    };
+
     let executor = Executor::new(
         resolved,
         registry,
         backend_registry,
         output_config,
         args.dry_run,
+        startup,
     );
     let exec_handle = std::thread::spawn(move || executor.run(&cmd_rx, &event_tx, sink));
 

--- a/crates/rite-cli/src/system_info.rs
+++ b/crates/rite-cli/src/system_info.rs
@@ -1,0 +1,89 @@
+//! Assembly of the [`SystemInfo`] and [`Environment`] snapshots.
+//!
+//! This is the single source for build identity: the `RITE_BUILD_*` constants
+//! are produced by this crate's `build.rs`, so they are only reachable here.
+//! Both the System tab (via UI signals) and `rite version --verbose` consume
+//! what this module gathers.
+
+use rite_runtime::{BuildInfo, Environment, HostInfo, SystemInfo};
+
+/// Assemble static build and host identity.
+#[must_use]
+pub fn gather_system() -> SystemInfo {
+    SystemInfo {
+        build: build_info(),
+        host: host_info(),
+        backends: backends(),
+    }
+}
+
+/// Gather the live device environment (disks today).
+#[must_use]
+pub fn gather_environment() -> Environment {
+    #[cfg(feature = "verification")]
+    {
+        rite_stdlib::gather_environment()
+    }
+    #[cfg(not(feature = "verification"))]
+    {
+        Environment::default()
+    }
+}
+
+fn build_info() -> BuildInfo {
+    BuildInfo {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        commit: env!("RITE_BUILD_COMMIT").to_string(),
+        commit_date: env!("RITE_BUILD_COMMIT_DATE").to_string(),
+        build_date: env!("RITE_BUILD_DATE").to_string(),
+        target: env!("RITE_BUILD_TARGET").to_string(),
+        profile: env!("RITE_BUILD_PROFILE").to_string(),
+        features: env!("RITE_BUILD_FEATURES").to_string(),
+        rustc: env!("RITE_BUILD_RUSTC").to_string(),
+    }
+}
+
+fn host_info() -> HostInfo {
+    // The System tab header uses the cheap `Basic` scope: no subprocess, no
+    // full CPU refresh. Richer host facts (CPU, machine id, hardening) are the
+    // `machine_info` action's job and land in the transcript, not the header.
+    #[cfg(feature = "verification")]
+    {
+        rite_stdlib::gather_host_info(rite_stdlib::HostInfoScope::Basic)
+    }
+    #[cfg(not(feature = "verification"))]
+    {
+        HostInfo {
+            arch: std::env::consts::ARCH.to_string(),
+            os: Some(std::env::consts::OS.to_string()),
+            os_version: None,
+            kernel_version: None,
+            hostname: None,
+            machine_id: None,
+            cpu_model: None,
+            hardening: None,
+        }
+    }
+}
+
+fn backends() -> Vec<rite_runtime::BackendVersion> {
+    let mut backends = Vec::new();
+    #[cfg(feature = "openssl")]
+    {
+        backends.push(rite_runtime::BackendVersion {
+            provider: "openssl".to_string(),
+            version: openssl::version::version().to_string(),
+            source: Some(openssl_source().to_string()),
+        });
+    }
+    backends
+}
+
+#[cfg(feature = "openssl")]
+fn openssl_source() -> &'static str {
+    if cfg!(feature = "openssl-vendored") {
+        "vendored"
+    } else {
+        "system"
+    }
+}

--- a/crates/rite-cli/src/version.rs
+++ b/crates/rite-cli/src/version.rs
@@ -1,5 +1,7 @@
 use clap::Args as ClapArgs;
 
+use crate::system_info::gather_system;
+
 #[derive(ClapArgs, Debug)]
 pub struct Args {
     /// Print detailed build and environment diagnostics
@@ -8,29 +10,23 @@ pub struct Args {
 }
 
 pub fn run(args: &Args) {
-    println!("rite {}", env!("CARGO_PKG_VERSION"));
+    let info = gather_system();
+    println!("rite {}", info.build.version);
     if args.verbose {
-        println!("target: {}", env!("RITE_BUILD_TARGET"));
-        println!("profile: {}", env!("RITE_BUILD_PROFILE"));
-        println!("features: {}", env!("RITE_BUILD_FEATURES"));
-        println!("commit: {}", env!("RITE_BUILD_COMMIT"));
-        println!("commit_date: {}", env!("RITE_BUILD_COMMIT_DATE"));
-        println!("build_date: {}", env!("RITE_BUILD_DATE"));
-        println!("rustc: {}", env!("RITE_BUILD_RUSTC"));
-        #[cfg(feature = "openssl")]
-        println!("openssl: {}", openssl::version::version());
-        #[cfg(feature = "openssl")]
-        println!("openssl_source: {}", openssl_source());
+        println!("target: {}", info.build.target);
+        println!("profile: {}", info.build.profile);
+        println!("features: {}", info.build.features);
+        println!("commit: {}", info.build.commit);
+        println!("commit_date: {}", info.build.commit_date);
+        println!("build_date: {}", info.build.build_date);
+        println!("rustc: {}", info.build.rustc);
+        for backend in &info.backends {
+            println!("{}: {}", backend.provider, backend.version);
+            if let Some(source) = &backend.source {
+                println!("{}_source: {source}", backend.provider);
+            }
+        }
         println!("os: {}", std::env::consts::OS);
         println!("arch: {}", std::env::consts::ARCH);
-    }
-}
-
-#[cfg(feature = "openssl")]
-fn openssl_source() -> &'static str {
-    if cfg!(feature = "openssl-vendored") {
-        "vendored"
-    } else {
-        "system"
     }
 }

--- a/crates/rite-runtime/src/display.rs
+++ b/crates/rite-runtime/src/display.rs
@@ -66,9 +66,10 @@ pub fn fact_summary(fact: &StepFact) -> Option<(Icon, String)> {
 
 /// One-line summary of a [`UiSignal`] for live-frontend display.
 ///
-/// Returns `None` for signals that frontends handle out-of-band
-/// (currently [`UiSignal::CeremonyOverview`], which populates structured
-/// fields rather than a single narration line).
+/// Returns `None` for the structured signals that frontends handle
+/// out-of-band ([`UiSignal::CeremonyOverview`], [`UiSignal::SystemInfo`],
+/// [`UiSignal::Environment`]), which populate structured fields rather than a
+/// single narration line.
 #[must_use]
 pub fn signal_summary(signal: &UiSignal) -> Option<(Icon, String)> {
     match signal {
@@ -82,7 +83,9 @@ pub fn signal_summary(signal: &UiSignal) -> Option<(Icon, String)> {
             };
             Some((Icon::Spinner, text))
         }
-        UiSignal::CeremonyOverview { .. } => None,
+        UiSignal::CeremonyOverview { .. } | UiSignal::SystemInfo(_) | UiSignal::Environment(_) => {
+            None
+        }
     }
 }
 

--- a/crates/rite-runtime/src/lib.rs
+++ b/crates/rite-runtime/src/lib.rs
@@ -26,6 +26,7 @@ mod reporter;
 mod runner;
 mod state;
 mod step_info;
+mod system_info;
 pub mod test_support;
 mod transcript;
 mod transcript_sink;
@@ -45,6 +46,12 @@ pub use backend::{BackendFactory, BackendRegistry};
 pub use protocol::{
     ExecEvent, Icon, MaterialOverview, MaterialOverviewKind, PromptId, Response, UiCommand,
     UiSignal,
+};
+
+// Structured machine/build/environment facts carried by UI signals.
+pub use system_info::{
+    BackendVersion, BuildInfo, Disk, Environment, FeatureCheck, FeatureStatus, Hardening, HostInfo,
+    ParseError as SystemInfoParseError, StartupSnapshot, SystemInfo,
 };
 
 // Shared formatter for live frontends.

--- a/crates/rite-runtime/src/protocol.rs
+++ b/crates/rite-runtime/src/protocol.rs
@@ -16,6 +16,8 @@
 use rite_model::{Material, MaterialId, MaterialKind, Prompt, StepFact, StepId};
 use secrecy::SecretString;
 
+use crate::system_info::{Environment, SystemInfo};
+
 /// Identifier that pairs a prompt request with its matching response.
 ///
 /// Issued by the runtime when emitting [`ExecEvent::AwaitPrompt`]; echoed back
@@ -155,8 +157,31 @@ impl MaterialOverview {
 }
 
 /// Transient UI-only signal. Never written to the transcript.
+///
+/// Signals are operator-assistance, not evidence. A frontend may **drop any
+/// variant** without affecting correctness or the transcript (this is exactly
+/// why `headless` and `console` ignore most of them). To persist information,
+/// emit a [`StepFact`] from an action; nothing here is ever promoted into the
+/// transcript. See `docs/development/runtime-and-frontend.md` for the full
+/// fact-vs-signal model.
+///
+/// The enum is intentionally **not** `#[non_exhaustive]`: it is a
+/// workspace-internal protocol type, and forcing every frontend to match each
+/// variant exhaustively (no wildcard arms) is the wanted compile-time check
+/// that a new signal is consciously handled or ignored everywhere. Public-API
+/// enums still get `#[non_exhaustive]`.
+///
+/// Variants fall into three sub-families:
+/// - **narration**: ephemeral lines and progress ([`LogLine`](Self::LogLine),
+///   [`Progress`](Self::Progress)).
+/// - **one-shot structured**: a single snapshot emitted at ceremony start
+///   ([`CeremonyOverview`](Self::CeremonyOverview),
+///   [`SystemInfo`](Self::SystemInfo)).
+/// - **re-emittable structured**: state the runtime may resend during the run;
+///   the frontend replaces its view on each ([`Environment`](Self::Environment)).
 #[derive(Debug, Clone)]
 pub enum UiSignal {
+    // --- narration ---
     /// Human-readable narration line for the live UI.
     LogLine {
         /// Step the line belongs to (if any).
@@ -175,6 +200,8 @@ pub enum UiSignal {
         /// Optional completion fraction in `[0.0, 1.0]`.
         fraction: Option<f32>,
     },
+
+    // --- one-shot structured ---
     /// Descriptive metadata for the pre-ceremony overview screen. Emitted
     /// once, right after [`StepFact::CeremonyStarted`]. Deliberately kept
     /// out of the transcript: the YAML is the source of truth for these
@@ -189,6 +216,22 @@ pub enum UiSignal {
         /// Total number of steps in the execution plan.
         step_count: usize,
     },
+    /// Static build and host identity for the System tab. Emitted once, right
+    /// after [`CeremonyOverview`](Self::CeremonyOverview). UI-only: machine
+    /// identity that belongs in the transcript is recorded by the
+    /// `machine_info` action, not fed in through this channel.
+    ///
+    /// Boxed: [`SystemInfo`] is much larger than the other variants, and
+    /// keeping the enum (and `ExecEvent`) small avoids bloating every
+    /// channel message.
+    SystemInfo(Box<SystemInfo>),
+
+    // --- re-emittable structured ---
+    /// Live device inventory for the System tab. Emitted once today, but
+    /// shaped to be **re-emitted**: the frontend replaces its environment view
+    /// on each, so a future live observer is purely additive. UI-only, never
+    /// persisted.
+    Environment(Environment),
 }
 
 /// Event emitted by the runtime to the frontend.

--- a/crates/rite-runtime/src/reporter.rs
+++ b/crates/rite-runtime/src/reporter.rs
@@ -105,9 +105,12 @@ impl<'a> Reporter<'a> {
 
     /// Record a transcript-worthy fact.
     ///
-    /// Writes to the transcript sink synchronously, then forwards to the
-    /// UI as [`ExecEvent::Fact`]. The transcript is flushed before the UI
-    /// observes the fact.
+    /// Facts are the audit record: everything durable flows through here, and
+    /// it comes from an action in the plan (plus the runner's own lifecycle
+    /// facts). Writes to the transcript sink synchronously, then forwards to
+    /// the UI as [`ExecEvent::Fact`]. The transcript is flushed before the UI
+    /// observes the fact. To surface something to the operator *without*
+    /// recording it, use [`Reporter::signal`] / [`Reporter::log`] instead.
     ///
     /// # Errors
     ///
@@ -123,10 +126,13 @@ impl<'a> Reporter<'a> {
 
     /// Emit a raw [`UiSignal`]. Never recorded to the transcript.
     ///
-    /// Most callers should use the specialized helpers ([`Reporter::log`]
-    /// for narration, [`Reporter::progress`] for spinners). This method
-    /// exists for structured one-shot signals (e.g. the pre-ceremony
-    /// overview) that don't fit either shape.
+    /// Signals are ephemeral operator-assistance: a frontend may drop any of
+    /// them without affecting correctness or the transcript. They are never
+    /// promoted into the audit record; use [`Reporter::fact`] for anything
+    /// that must persist. Most callers should use the specialized helpers
+    /// ([`Reporter::log`] for narration, [`Reporter::progress`] for spinners).
+    /// This method exists for structured signals (e.g. the pre-ceremony
+    /// overview, the system snapshot) that don't fit either shape.
     ///
     /// # Errors
     ///

--- a/crates/rite-runtime/src/runner.rs
+++ b/crates/rite-runtime/src/runner.rs
@@ -51,6 +51,7 @@ use crate::protocol::{ExecEvent, Icon, MaterialOverview, UiCommand, UiSignal};
 use crate::reporter::{Reporter, ReporterError};
 use crate::state::{ExecutionState, HandlerContext, StepResult};
 use crate::step_info::StepInfo;
+use crate::system_info::StartupSnapshot;
 use crate::transcript_sink::{TranscriptFingerprint, TranscriptSink};
 use rite_model::{ErrorRecord, Prompt, StepFact, StepOutcome};
 
@@ -207,10 +208,15 @@ pub struct Executor {
     backend_registry: BackendRegistry,
     output_config: OutputConfig,
     dry_run: bool,
+    startup: StartupSnapshot,
 }
 
 impl Executor {
     /// Build an executor for a single ceremony run.
+    ///
+    /// `startup` carries the system identity and device environment the CLI
+    /// gathered at launch; the executor echoes them to the frontend as UI
+    /// signals at ceremony start and does not otherwise inspect them.
     #[must_use]
     pub fn new(
         ceremony: Ceremony,
@@ -218,6 +224,7 @@ impl Executor {
         backend_registry: BackendRegistry,
         output_config: OutputConfig,
         dry_run: bool,
+        startup: StartupSnapshot,
     ) -> Self {
         Self {
             ceremony,
@@ -225,6 +232,7 @@ impl Executor {
             backend_registry,
             output_config,
             dry_run,
+            startup,
         }
     }
 
@@ -346,6 +354,13 @@ impl Executor {
                 .collect(),
             step_count: self.ceremony.execution_plan.len(),
         })?;
+
+        // Machine identity and device environment for the System tab. Both
+        // UI-only: identity that belongs in the transcript is recorded by the
+        // `machine_info` action, not fed in here. `Environment` is emitted
+        // once today but shaped to be re-emitted by a future live observer.
+        reporter.signal(UiSignal::SystemInfo(Box::new(self.startup.system.clone())))?;
+        reporter.signal(UiSignal::Environment(self.startup.environment.clone()))?;
 
         // Ceremony-start gate: let the operator review the overview
         // before any side effect (material loading, first step body). The
@@ -653,6 +668,7 @@ sections:
             BackendRegistry::new(),
             dry_run_output_config(),
             true,
+            StartupSnapshot::placeholder(),
         );
 
         let join = std::thread::spawn(move || executor.run(&cmd_rx, &event_tx, sink));
@@ -733,6 +749,7 @@ sections:
             BackendRegistry::new(),
             dry_run_output_config(),
             false, // dry_run=false so prompts actually fire
+            StartupSnapshot::placeholder(),
         );
 
         // Drive the frontend on a worker so the executor's prompt waits
@@ -865,6 +882,7 @@ sections:
             BackendRegistry::new(),
             dry_run_output_config(),
             true,
+            StartupSnapshot::placeholder(),
         );
 
         let join = std::thread::spawn(move || executor.run(&cmd_rx, &event_tx, sink));

--- a/crates/rite-runtime/src/system_info.rs
+++ b/crates/rite-runtime/src/system_info.rs
@@ -1,0 +1,322 @@
+//! Structured machine, build, and environment facts surfaced to frontends.
+//!
+//! Two distinct shapes live here, on opposite sides of the data-flow boundary
+//! described in `docs/development/runtime-and-frontend.md`:
+//!
+//! - [`SystemInfo`] is **static identity**: the build that is running and the
+//!   host it runs on. Gathered once at startup. The same typed host shape
+//!   ([`HostInfo`]) is what the `machine_info` action records to the
+//!   transcript, so the model is defined once and shared.
+//! - [`Environment`] is the **live device inventory** (disks today;
+//!   peripherals and network later). It is deliberately shaped to be
+//!   re-emitted: a future observer can resend it and a frontend replaces its
+//!   view wholesale. Items carry a stable key for later diffing.
+//!
+//! Both travel as UI-only signals ([`crate::UiSignal`]); neither is ever
+//! written to the transcript. Recording machine identity as evidence is the
+//! `machine_info` action's job, not the frontend's.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Failure to parse one of this module's string-backed enums.
+///
+/// Shared across the enums defined here, mirroring the pattern in
+/// `rite-sdk` (`rite_sdk::ParseError`), which is not constructible outside
+/// its own crate.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("unknown value: {0:?}")]
+pub struct ParseError(String);
+
+/// Static build and host identity for the System tab and
+/// `rite version --verbose`.
+///
+/// Assembled by the CLI, the only crate that holds the build-time constants,
+/// and echoed to the frontend once via [`crate::UiSignal::SystemInfo`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SystemInfo {
+    /// Identity of the running binary.
+    pub build: BuildInfo,
+    /// Identity of the host it runs on.
+    pub host: HostInfo,
+    /// Linked cryptographic backend libraries.
+    pub backends: Vec<BackendVersion>,
+}
+
+/// Identity of the running `rite` binary. A property of the artifact, set at
+/// compile time; the strongly verifiable end of the trust boundary (checkable
+/// against a release tag and build provenance).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BuildInfo {
+    /// Crate version (`CARGO_PKG_VERSION`).
+    pub version: String,
+    /// Git commit the binary was built from, or `"unknown"`.
+    pub commit: String,
+    /// Commit date, or `"unknown"`.
+    pub commit_date: String,
+    /// Date the binary was built.
+    pub build_date: String,
+    /// Target triple.
+    pub target: String,
+    /// Build profile (`debug` / `release`).
+    pub profile: String,
+    /// Enabled cargo features, comma-separated.
+    pub features: String,
+    /// Compiler version string.
+    pub rustc: String,
+}
+
+/// A linked cryptographic backend library and its runtime version.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackendVersion {
+    /// Provider key (e.g. `"openssl"`).
+    pub provider: String,
+    /// Runtime-linked library version.
+    pub version: String,
+    /// How the library was linked (e.g. `"vendored"` / `"system"`).
+    pub source: Option<String>,
+}
+
+/// Identity of the host machine. A property of the environment, the weakly
+/// verifiable end of the trust boundary (an operator assertion that software
+/// can only partly corroborate).
+///
+/// Optional fields are populated depending on the gathering scope: a cheap
+/// startup snapshot fills only the always-present basics, while the
+/// `machine_info` action fills the full set.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HostInfo {
+    /// CPU architecture (`std::env::consts::ARCH`). Always present.
+    pub arch: String,
+    /// OS name (e.g. `"Linux"`, `"Darwin"`).
+    pub os: Option<String>,
+    /// Long OS version string.
+    pub os_version: Option<String>,
+    /// Kernel version.
+    pub kernel_version: Option<String>,
+    /// Hostname.
+    pub hostname: Option<String>,
+    /// Hashed machine identifier (SHA-256), when available.
+    pub machine_id: Option<String>,
+    /// CPU brand string.
+    pub cpu_model: Option<String>,
+    /// Platform security posture, when gathered at full scope.
+    pub hardening: Option<Hardening>,
+}
+
+/// Snapshot of platform memory- and DMA-protection features.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Hardening {
+    /// Hardware RAM encryption (AMD SME, Intel TME, Apple Secure Enclave).
+    pub ram_encryption: FeatureCheck,
+    /// IOMMU-based DMA protection.
+    pub dma_protection: FeatureCheck,
+    /// Zeroing of freed pages.
+    pub freed_page_zeroing: FeatureCheck,
+}
+
+/// A single security-feature determination: a machine-comparable status plus
+/// optional human context. Replaces the free-form status strings the
+/// `machine_info` action used to emit.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeatureCheck {
+    /// Whether the feature is active.
+    pub status: FeatureStatus,
+    /// Human-readable context (e.g. `"AMD SME"`, `"enable TME in BIOS"`).
+    pub detail: Option<String>,
+}
+
+impl FeatureCheck {
+    /// Construct a check with no detail.
+    #[must_use]
+    pub fn new(status: FeatureStatus) -> Self {
+        Self {
+            status,
+            detail: None,
+        }
+    }
+
+    /// Construct a check carrying human context.
+    #[must_use]
+    pub fn with_detail(status: FeatureStatus, detail: impl Into<String>) -> Self {
+        Self {
+            status,
+            detail: Some(detail.into()),
+        }
+    }
+}
+
+/// Status of a platform security feature.
+///
+/// Serialized via its [`Display`](fmt::Display) form so the transcript carries
+/// a stable, comparable token rather than a sentence. Follows the
+/// Display/serde alignment convention used by `rite-sdk` enums.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(into = "String", try_from = "String")]
+#[non_exhaustive]
+pub enum FeatureStatus {
+    /// Present and active.
+    Active,
+    /// Supported by the platform but currently off.
+    Inactive,
+    /// Not available on this hardware or platform.
+    Unavailable,
+    /// Not a meaningful concept on this platform.
+    NotApplicable,
+    /// Could not be determined.
+    Unknown,
+}
+
+impl fmt::Display for FeatureStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            FeatureStatus::Active => "active",
+            FeatureStatus::Inactive => "inactive",
+            FeatureStatus::Unavailable => "unavailable",
+            FeatureStatus::NotApplicable => "not_applicable",
+            FeatureStatus::Unknown => "unknown",
+        };
+        f.write_str(s)
+    }
+}
+
+impl std::str::FromStr for FeatureStatus {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(Self::Active),
+            "inactive" => Ok(Self::Inactive),
+            "unavailable" => Ok(Self::Unavailable),
+            "not_applicable" => Ok(Self::NotApplicable),
+            "unknown" => Ok(Self::Unknown),
+            _ => Err(ParseError(s.to_owned())),
+        }
+    }
+}
+
+impl From<FeatureStatus> for String {
+    fn from(s: FeatureStatus) -> String {
+        s.to_string()
+    }
+}
+
+impl TryFrom<String> for FeatureStatus {
+    type Error = ParseError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        s.parse()
+    }
+}
+
+/// Live inventory of the machine's attached devices.
+///
+/// UI-only and never serialized. Shaped to be **re-emitted**: a frontend
+/// replaces its whole view on each [`crate::UiSignal::Environment`], so a
+/// future live observer is purely additive. Each item carries a stable key
+/// (e.g. [`Disk::name`]) for later diffing.
+#[derive(Debug, Clone, Default)]
+pub struct Environment {
+    /// Block devices and their mounts.
+    pub disks: Vec<Disk>,
+    // Future: peripherals (USB / smartcard / TPM), network interfaces.
+}
+
+/// The one-shot UI snapshots emitted at ceremony start: static system
+/// identity and the initial device environment.
+///
+/// Assembled by the CLI (the only crate holding the build-time constants) and
+/// handed to the executor, which echoes the two pieces as
+/// [`crate::UiSignal::SystemInfo`] and [`crate::UiSignal::Environment`]. The
+/// runtime treats this purely as a pass-through; it never inspects the
+/// contents.
+#[derive(Debug, Clone)]
+pub struct StartupSnapshot {
+    /// Static build and host identity.
+    pub system: SystemInfo,
+    /// Initial device environment.
+    pub environment: Environment,
+}
+
+impl StartupSnapshot {
+    /// A placeholder snapshot with no resolved build or host data. Used by
+    /// runtime tests, which do not exercise the System tab.
+    #[cfg(test)]
+    pub(crate) fn placeholder() -> Self {
+        let unknown = || "unknown".to_string();
+        Self {
+            system: SystemInfo {
+                build: BuildInfo {
+                    version: unknown(),
+                    commit: unknown(),
+                    commit_date: unknown(),
+                    build_date: unknown(),
+                    target: unknown(),
+                    profile: unknown(),
+                    features: String::new(),
+                    rustc: unknown(),
+                },
+                host: HostInfo {
+                    arch: std::env::consts::ARCH.to_string(),
+                    os: None,
+                    os_version: None,
+                    kernel_version: None,
+                    hostname: None,
+                    machine_id: None,
+                    cpu_model: None,
+                    hardening: None,
+                },
+                backends: Vec::new(),
+            },
+            environment: Environment::default(),
+        }
+    }
+}
+
+/// A block device and its mount, as shown in the System tab.
+#[derive(Debug, Clone)]
+pub struct Disk {
+    /// Device name; the stable key for diffing across re-emissions.
+    pub name: String,
+    /// Mount point path.
+    pub mount_point: String,
+    /// Filesystem type, when known.
+    pub file_system: Option<String>,
+    /// Total capacity in bytes.
+    pub total_bytes: u64,
+    /// Free space in bytes.
+    pub available_bytes: u64,
+    /// Whether the device is removable.
+    pub removable: bool,
+    /// Device kind (e.g. `"SSD"`, `"HDD"`), when known.
+    pub kind: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn feature_status_round_trips_through_display_and_serde() {
+        for status in [
+            FeatureStatus::Active,
+            FeatureStatus::Inactive,
+            FeatureStatus::Unavailable,
+            FeatureStatus::NotApplicable,
+            FeatureStatus::Unknown,
+        ] {
+            let text = status.to_string();
+            assert_eq!(text.parse::<FeatureStatus>().expect("parses"), status);
+            let json = serde_json::to_string(&status).expect("serializes");
+            assert_eq!(json, format!("\"{text}\""));
+            let back: FeatureStatus = serde_json::from_str(&json).expect("deserializes");
+            assert_eq!(back, status);
+        }
+    }
+
+    #[test]
+    fn unknown_feature_status_string_is_rejected() {
+        assert!("bogus".parse::<FeatureStatus>().is_err());
+    }
+}

--- a/crates/rite-stdlib/src/lib.rs
+++ b/crates/rite-stdlib/src/lib.rs
@@ -57,7 +57,8 @@ pub use crypto::{ExportPublicAction, GenerateKeypairAction, UnwrapKeyAction, Wra
 pub use pki::{GenerateCsrAction, IssueCertificateAction};
 #[cfg(feature = "verification")]
 pub use verification::{
-    CheckValueAction, ClockCheckAction, ConfirmAction, MachineInfoAction, OralReadbackAction,
+    CheckValueAction, ClockCheckAction, ConfirmAction, HostInfoScope, MachineInfoAction,
+    OralReadbackAction, gather_environment, gather_host_info,
 };
 
 /// Create a new action registry with all standard-library actions registered.

--- a/crates/rite-stdlib/src/verification/host.rs
+++ b/crates/rite-stdlib/src/verification/host.rs
@@ -1,0 +1,253 @@
+//! Host and device gathering shared by the `machine_info` action and the
+//! System tab.
+//!
+//! The probes live here, behind the `verification` feature (which pulls
+//! `sysinfo`), and return the typed shapes defined in `rite-runtime`. Keeping
+//! a single source means the recorded evidence (`machine_info`) and the live
+//! UI dashboard cannot drift.
+
+use rite_runtime::{Disk, Environment, FeatureCheck, FeatureStatus, Hardening, HostInfo};
+use sysinfo::{CpuRefreshKind, RefreshKind, System};
+
+/// How much host detail to gather.
+///
+/// `Basic` is cheap enough to run at every startup for the System tab header:
+/// it touches no subprocess and does not refresh the full CPU list. `Full`
+/// adds the heavier probes (CPU, hashed machine id, and the security-feature
+/// inspection, which spawns `dmesg` on Linux) and is used by the
+/// `machine_info` action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostInfoScope {
+    /// Architecture, OS name/version, hostname.
+    Basic,
+    /// Everything in `Basic` plus kernel, CPU, machine id, and hardening.
+    Full,
+}
+
+/// Gather host identity at the requested scope.
+#[must_use]
+pub fn gather_host_info(scope: HostInfoScope) -> HostInfo {
+    // These are associated functions in `sysinfo`; no `System` instance or
+    // refresh is needed, so the `Basic` scope stays cheap.
+    let os = System::name();
+    let os_version = System::long_os_version();
+    let hostname = get_hostname();
+
+    let mut info = HostInfo {
+        arch: std::env::consts::ARCH.to_string(),
+        os,
+        os_version,
+        kernel_version: None,
+        hostname: Some(hostname),
+        machine_id: None,
+        cpu_model: None,
+        hardening: None,
+    };
+
+    if scope == HostInfoScope::Full {
+        info.kernel_version = System::kernel_version();
+        info.cpu_model = cpu_model();
+        info.machine_id = get_machine_id();
+        info.hardening = Some(collect_security_features());
+    }
+
+    info
+}
+
+/// Gather the live device environment. MVP: block devices.
+#[must_use]
+pub fn gather_environment() -> Environment {
+    let disks = sysinfo::Disks::new_with_refreshed_list();
+    let disks = disks
+        .list()
+        .iter()
+        .map(|d| {
+            let file_system = osstr_opt(d.file_system());
+            let kind = match d.kind() {
+                sysinfo::DiskKind::Unknown(_) => None,
+                other => Some(other.to_string()),
+            };
+            Disk {
+                name: d.name().to_string_lossy().into_owned(),
+                mount_point: d.mount_point().to_string_lossy().into_owned(),
+                file_system,
+                total_bytes: d.total_space(),
+                available_bytes: d.available_space(),
+                removable: d.is_removable(),
+                kind,
+            }
+        })
+        .collect();
+    Environment { disks }
+}
+
+fn osstr_opt(value: &std::ffi::OsStr) -> Option<String> {
+    let s = value.to_string_lossy();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s.into_owned())
+    }
+}
+
+fn get_hostname() -> String {
+    System::host_name()
+        .or_else(|| std::env::var("HOSTNAME").ok())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn cpu_model() -> Option<String> {
+    // Refresh CPUs only: the brand is all we need, so skip the
+    // process/memory scan a full `System::new_all()` would run.
+    let sys =
+        System::new_with_specifics(RefreshKind::nothing().with_cpu(CpuRefreshKind::everything()));
+    sys.cpus()
+        .first()
+        .map(|c| c.brand().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+#[cfg(target_os = "linux")]
+fn get_machine_id() -> Option<String> {
+    let raw_id = std::fs::read_to_string("/etc/machine-id").ok()?;
+    let trimmed = raw_id.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(rite_runtime::compute_fingerprint(trimmed.as_bytes()))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn get_machine_id() -> Option<String> {
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn collect_security_features() -> Hardening {
+    let dmesg_out = std::process::Command::new("dmesg")
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
+        .unwrap_or_default();
+
+    let ram_encryption = if dmesg_out.contains("AMD Memory Encryption Features active: SME") {
+        FeatureCheck::with_detail(FeatureStatus::Active, "AMD SME")
+    } else if dmesg_out.contains("x86/tme: enabled by BIOS")
+        || dmesg_out.contains("x86/mktme: enabled by BIOS")
+    {
+        FeatureCheck::with_detail(FeatureStatus::Active, "Intel TME")
+    } else {
+        let vendor = std::fs::read_to_string("/proc/cpuinfo")
+            .unwrap_or_default()
+            .lines()
+            .find(|l| l.starts_with("vendor_id"))
+            .and_then(|l| l.split(':').nth(1))
+            .map_or_else(|| "unknown".to_string(), |v| v.trim().to_string());
+        match vendor.as_str() {
+            "AuthenticAMD" => FeatureCheck::with_detail(
+                FeatureStatus::Inactive,
+                "AMD CPU; SME not supported or disabled in BIOS",
+            ),
+            "GenuineIntel" => FeatureCheck::with_detail(
+                FeatureStatus::Inactive,
+                "Intel CPU; enable TME in BIOS/UEFI Security settings",
+            ),
+            other => FeatureCheck::with_detail(FeatureStatus::Inactive, other.to_string()),
+        }
+    };
+
+    let iommu_count = std::fs::read_dir("/sys/class/iommu").map_or(0, std::iter::Iterator::count);
+    let dma_protection = if iommu_count > 0 {
+        FeatureCheck::with_detail(FeatureStatus::Active, format!("{iommu_count} groups"))
+    } else {
+        FeatureCheck::new(FeatureStatus::Inactive)
+    };
+
+    let freed_page_zeroing =
+        if std::fs::read_to_string("/proc/cmdline").is_ok_and(|c| c.contains("init_on_free=1")) {
+            FeatureCheck::new(FeatureStatus::Active)
+        } else {
+            FeatureCheck::new(FeatureStatus::Inactive)
+        };
+
+    Hardening {
+        ram_encryption,
+        dma_protection,
+        freed_page_zeroing,
+    }
+}
+
+// Apple Silicon has always-on hardware memory encryption via the Secure
+// Enclave. DART (per-device IOMMU) is also always active on Apple Silicon.
+// Intel Macs have neither; the T2 chip encrypts the SSD only, not RAM.
+#[cfg(target_os = "macos")]
+fn collect_security_features() -> Hardening {
+    let apple_silicon = std::env::consts::ARCH == "aarch64";
+    let (ram_encryption, dma_protection) = if apple_silicon {
+        (
+            FeatureCheck::with_detail(
+                FeatureStatus::Active,
+                "Apple Silicon: always-on hardware encryption via Secure Enclave",
+            ),
+            FeatureCheck::with_detail(
+                FeatureStatus::Active,
+                "Apple Silicon: DART per-device IOMMU always on",
+            ),
+        )
+    } else {
+        (
+            FeatureCheck::with_detail(
+                FeatureStatus::Inactive,
+                "Intel Mac: T2 chip encrypts SSD only, not RAM",
+            ),
+            FeatureCheck::with_detail(FeatureStatus::Unavailable, "Intel Mac"),
+        )
+    };
+    Hardening {
+        ram_encryption,
+        dma_protection,
+        freed_page_zeroing: FeatureCheck::with_detail(FeatureStatus::NotApplicable, "macOS"),
+    }
+}
+
+// Windows and other platforms report everything as unavailable for now.
+// TODO(windows): probe real posture (BitLocker, VBS/HVCI, Kernel DMA
+// Protection). Low priority: the Windows binary is meant for authoring
+// ceremonies, not running them, where this posture matters.
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn collect_security_features() -> Hardening {
+    Hardening {
+        ram_encryption: FeatureCheck::new(FeatureStatus::Unavailable),
+        dma_protection: FeatureCheck::new(FeatureStatus::Unavailable),
+        freed_page_zeroing: FeatureCheck::new(FeatureStatus::Unavailable),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_scope_leaves_full_only_fields_unset() {
+        let info = gather_host_info(HostInfoScope::Basic);
+        assert!(!info.arch.is_empty());
+        assert!(info.kernel_version.is_none());
+        assert!(info.cpu_model.is_none());
+        assert!(info.hardening.is_none());
+    }
+
+    #[test]
+    fn full_scope_populates_hardening() {
+        let info = gather_host_info(HostInfoScope::Full);
+        assert!(info.hardening.is_some());
+    }
+
+    #[test]
+    fn environment_lists_disks() {
+        // The list may be empty in constrained CI sandboxes; just exercise
+        // the gather path and the field mapping.
+        let env = gather_environment();
+        for disk in &env.disks {
+            assert!(!disk.name.is_empty() || !disk.mount_point.is_empty());
+        }
+    }
+}

--- a/crates/rite-stdlib/src/verification/machine_info.rs
+++ b/crates/rite-stdlib/src/verification/machine_info.rs
@@ -2,148 +2,32 @@
 
 use rite_model::{ActionType, StepFact};
 use rite_runtime::{
-    Action, ActionCategory, ActionError, ActionMetadata, HandlerContext, Icon, Reporter, StepInfo,
-    StepResult, parse_params,
+    Action, ActionCategory, ActionError, ActionMetadata, FeatureCheck, HandlerContext, HostInfo,
+    Icon, Reporter, StepInfo, StepResult, parse_params,
 };
 use rite_sdk::Backend;
-use sysinfo::System;
 
 use crate::params::MachineInfoParams;
+use crate::verification::host::{HostInfoScope, gather_host_info};
 
 /// Capture hostname, machine ID, CPU model, OS information, and a
 /// snapshot of platform security features as transcript evidence.
 ///
 /// The machine ID (when available) is hashed with SHA-256 for privacy.
+///
+/// The gathering is shared with the System tab via
+/// [`gather_host_info`](crate::verification::gather_host_info); this action
+/// records a point-in-time snapshot as evidence, while the tab shows a live
+/// view. The action's parameters select which parts of the gathered
+/// [`HostInfo`] are logged and persisted.
 pub struct MachineInfoAction;
 
-fn get_hostname() -> String {
-    System::host_name()
-        .or_else(|| std::env::var("HOSTNAME").ok())
-        .unwrap_or_else(|| "unknown".to_string())
-}
-
-#[cfg(target_os = "linux")]
-fn get_machine_id() -> Option<String> {
-    let raw_id = std::fs::read_to_string("/etc/machine-id").ok()?;
-    let trimmed = raw_id.trim();
-    if trimmed.is_empty() {
-        return None;
+/// Format a feature check as `status` or `status (detail)`.
+fn format_feature(check: &FeatureCheck) -> String {
+    match &check.detail {
+        Some(detail) => format!("{} ({detail})", check.status),
+        None => check.status.to_string(),
     }
-    Some(rite_runtime::compute_fingerprint(trimmed.as_bytes()))
-}
-
-#[cfg(not(target_os = "linux"))]
-fn get_machine_id() -> Option<String> {
-    None
-}
-
-/// Security feature status. Each field is a human-readable status string.
-struct SecurityFeatures {
-    hardware_ram_encryption: String,
-    iommu_dma_protection: String,
-    freed_page_zeroing: String,
-}
-
-#[cfg(target_os = "linux")]
-fn collect_security_features() -> SecurityFeatures {
-    let dmesg_out = std::process::Command::new("dmesg")
-        .output()
-        .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
-        .unwrap_or_default();
-
-    let hardware_ram_encryption =
-        if dmesg_out.contains("AMD Memory Encryption Features active: SME") {
-            "AMD SME active".to_string()
-        } else if dmesg_out.contains("x86/tme: enabled by BIOS")
-            || dmesg_out.contains("x86/mktme: enabled by BIOS")
-        {
-            "Intel TME active".to_string()
-        } else {
-            let vendor = std::fs::read_to_string("/proc/cpuinfo")
-                .unwrap_or_default()
-                .lines()
-                .find(|l| l.starts_with("vendor_id"))
-                .and_then(|l| l.split(':').nth(1))
-                .map_or_else(|| "unknown".to_string(), |v| v.trim().to_string());
-            match vendor.as_str() {
-                "AuthenticAMD" => {
-                    "not active (AMD CPU; SME not supported or disabled in BIOS)".to_string()
-                }
-                "GenuineIntel" => {
-                    "not active (Intel CPU; enable TME in BIOS/UEFI Security settings)".to_string()
-                }
-                _ => format!("not active ({vendor})"),
-            }
-        };
-
-    let iommu_count = std::fs::read_dir("/sys/class/iommu").map_or(0, std::iter::Iterator::count);
-    let iommu_dma_protection = if iommu_count > 0 {
-        format!("active ({iommu_count} groups)")
-    } else {
-        "not active".to_string()
-    };
-
-    let freed_page_zeroing =
-        if std::fs::read_to_string("/proc/cmdline").is_ok_and(|c| c.contains("init_on_free=1")) {
-            "active".to_string()
-        } else {
-            "not active".to_string()
-        };
-
-    SecurityFeatures {
-        hardware_ram_encryption,
-        iommu_dma_protection,
-        freed_page_zeroing,
-    }
-}
-
-// Apple Silicon has always-on hardware memory encryption via the Secure Enclave.
-// DART (per-device IOMMU) is also always active on Apple Silicon.
-// Intel Macs have neither; the T2 chip encrypts the SSD only, not RAM.
-#[cfg(target_os = "macos")]
-fn collect_security_features() -> SecurityFeatures {
-    let apple_silicon = std::env::consts::ARCH == "aarch64";
-    SecurityFeatures {
-        hardware_ram_encryption: if apple_silicon {
-            "active (Apple Silicon: always-on hardware encryption via Secure Enclave)".to_string()
-        } else {
-            "not active (Intel Mac: T2 chip encrypts SSD only, not RAM)".to_string()
-        },
-        iommu_dma_protection: if apple_silicon {
-            "active (Apple Silicon: DART per-device IOMMU always on)".to_string()
-        } else {
-            "not available (Intel Mac)".to_string()
-        },
-        freed_page_zeroing: "not applicable (macOS)".to_string(),
-    }
-}
-
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
-fn collect_security_features() -> SecurityFeatures {
-    SecurityFeatures {
-        hardware_ram_encryption: "not available".to_string(),
-        iommu_dma_protection: "not available".to_string(),
-        freed_page_zeroing: "not available".to_string(),
-    }
-}
-
-fn collect_system_info() -> (
-    Option<String>,
-    Option<String>,
-    Option<String>,
-    Option<String>,
-) {
-    let mut sys = System::new_all();
-    sys.refresh_all();
-    (
-        sys.cpus()
-            .first()
-            .map(|c| c.brand().to_string())
-            .filter(|s| !s.is_empty()),
-        System::name(),
-        System::long_os_version(),
-        System::kernel_version(),
-    )
 }
 
 impl Action for MachineInfoAction {
@@ -171,101 +55,76 @@ impl Action for MachineInfoAction {
 
         reporter.log(Icon::Info, "Capturing machine information...")?;
 
-        let hostname = get_hostname();
-        let machine_id = get_machine_id();
-        let (cpu_model, os_name, os_version, kernel_version) = collect_system_info();
-
-        reporter.log(Icon::Info, format!("Hostname:        {hostname}"))?;
-
-        if typed.include_machine_id
-            && let Some(ref mid) = machine_id
-        {
-            reporter.log(Icon::Info, format!("Machine ID:      {mid}"))?;
+        // Gather the full host snapshot, then project it down to the parts the
+        // ceremony asked to record.
+        let mut info = gather_host_info(HostInfoScope::Full);
+        if !typed.include_machine_id {
+            info.machine_id = None;
+        }
+        if !typed.include_cpu {
+            info.cpu_model = None;
+        }
+        if !typed.include_os {
+            info.os = None;
+            info.os_version = None;
+            info.kernel_version = None;
+        }
+        if !typed.include_security_features {
+            info.hardening = None;
         }
 
-        if typed.include_cpu
-            && let Some(ref cpu) = cpu_model
-        {
-            reporter.log(Icon::Info, format!("CPU:             {cpu}"))?;
-        }
+        log_host_info(&info, reporter)?;
 
-        if typed.include_os {
-            if let Some(ref os) = os_name {
-                reporter.log(Icon::Info, format!("OS:              {os}"))?;
-            }
-            if let Some(ref osv) = os_version {
-                reporter.log(Icon::Info, format!("OS Version:      {osv}"))?;
-            }
-            if let Some(ref kv) = kernel_version {
-                reporter.log(Icon::Info, format!("Kernel Version:  {kv}"))?;
-            }
-        }
-
-        let security_features = if typed.include_security_features {
-            let f = collect_security_features();
-            reporter.log(
-                Icon::Info,
-                format!("RAM Encryption:  {}", f.hardware_ram_encryption),
-            )?;
-            reporter.log(
-                Icon::Info,
-                format!("DMA Protection:  {}", f.iommu_dma_protection),
-            )?;
-            reporter.log(
-                Icon::Info,
-                format!("Page Zeroing:    {}", f.freed_page_zeroing),
-            )?;
-            Some(f)
-        } else {
-            None
-        };
-
-        let mut outputs = serde_json::Map::new();
-        outputs.insert("hostname".to_string(), hostname.into());
-        if typed.include_machine_id
-            && let Some(mid) = machine_id
-        {
-            outputs.insert("machine_id".to_string(), mid.into());
-        }
-        if typed.include_cpu
-            && let Some(cpu) = cpu_model
-        {
-            outputs.insert("cpu_model".to_string(), cpu.into());
-        }
-        if typed.include_os {
-            if let Some(os) = os_name {
-                outputs.insert("os_name".to_string(), os.into());
-            }
-            if let Some(osv) = os_version {
-                outputs.insert("os_version".to_string(), osv.into());
-            }
-            if let Some(kv) = kernel_version {
-                outputs.insert("kernel_version".to_string(), kv.into());
-            }
-        }
-        if let Some(f) = security_features {
-            outputs.insert(
-                "hardware_ram_encryption".to_string(),
-                f.hardware_ram_encryption.into(),
-            );
-            outputs.insert(
-                "iommu_dma_protection".to_string(),
-                f.iommu_dma_protection.into(),
-            );
-            outputs.insert(
-                "freed_page_zeroing".to_string(),
-                f.freed_page_zeroing.into(),
-            );
-        }
+        // Serialize the typed, projected snapshot. Optional fields that were
+        // cleared above serialize as JSON null. `arch` is always present.
+        let outputs = serde_json::to_value(&info)
+            .map_err(|e| ActionError::Failed(format!("failed to serialize machine info: {e}")))?;
 
         reporter.fact(StepFact::BackendOperation {
             step: step.id.clone(),
             kind: "machine_info".to_string(),
             inputs: serde_json::Value::Null,
-            outputs: serde_json::Value::Object(outputs),
+            outputs,
             fingerprint: None,
         })?;
 
         Ok(StepResult::completed("Machine info captured"))
     }
+}
+
+/// Emit the human-readable log lines for a projected host snapshot.
+fn log_host_info(info: &HostInfo, reporter: &mut Reporter<'_>) -> Result<(), ActionError> {
+    if let Some(hostname) = &info.hostname {
+        reporter.log(Icon::Info, format!("Hostname:        {hostname}"))?;
+    }
+    if let Some(mid) = &info.machine_id {
+        reporter.log(Icon::Info, format!("Machine ID:      {mid}"))?;
+    }
+    if let Some(cpu) = &info.cpu_model {
+        reporter.log(Icon::Info, format!("CPU:             {cpu}"))?;
+    }
+    if let Some(os) = &info.os {
+        reporter.log(Icon::Info, format!("OS:              {os}"))?;
+    }
+    if let Some(osv) = &info.os_version {
+        reporter.log(Icon::Info, format!("OS Version:      {osv}"))?;
+    }
+    if let Some(kv) = &info.kernel_version {
+        reporter.log(Icon::Info, format!("Kernel Version:  {kv}"))?;
+    }
+    if let Some(h) = &info.hardening {
+        reporter.log(
+            Icon::Info,
+            format!("RAM Encryption:  {}", format_feature(&h.ram_encryption)),
+        )?;
+        reporter.log(
+            Icon::Info,
+            format!("DMA Protection:  {}", format_feature(&h.dma_protection)),
+        )?;
+        reporter.log(
+            Icon::Info,
+            format!("Page Zeroing:    {}", format_feature(&h.freed_page_zeroing)),
+        )?;
+    }
+    Ok(())
 }

--- a/crates/rite-stdlib/src/verification/mod.rs
+++ b/crates/rite-stdlib/src/verification/mod.rs
@@ -3,11 +3,13 @@
 mod check_value;
 mod clock_check;
 mod confirm;
+mod host;
 mod machine_info;
 mod oral_readback;
 
 pub use check_value::CheckValueAction;
 pub use clock_check::ClockCheckAction;
 pub use confirm::ConfirmAction;
+pub use host::{HostInfoScope, gather_environment, gather_host_info};
 pub use machine_info::MachineInfoAction;
 pub use oral_readback::OralReadbackAction;

--- a/crates/rite-tui/src/model.rs
+++ b/crates/rite-tui/src/model.rs
@@ -4,7 +4,7 @@ use std::collections::VecDeque;
 
 use chrono::{DateTime, Local, Timelike};
 use rite_model::{Prompt, StepId};
-use rite_runtime::{ExecEvent, Icon, MaterialOverview, PromptId};
+use rite_runtime::{Environment, ExecEvent, Icon, MaterialOverview, PromptId, SystemInfo};
 
 /// Maximum length of a deviation note. Anything longer is rejected before
 /// the command is sent, keeps the transcript line readable.
@@ -26,6 +26,12 @@ pub struct Model {
     pub ceremony_materials: Vec<MaterialOverview>,
     /// Total number of steps in the execution plan, when known.
     pub ceremony_step_count: Option<usize>,
+    /// Static build/host identity for the System tab. Populated from
+    /// `UiSignal::SystemInfo`, emitted once at ceremony start.
+    pub system_info: Option<SystemInfo>,
+    /// Live device environment for the System tab. Populated from
+    /// `UiSignal::Environment`; replaced wholesale on each re-emission.
+    pub environment: Option<Environment>,
     /// Current screen.
     pub screen: Screen,
     /// Screen to restore when a modal is dismissed. `None` when the
@@ -65,6 +71,8 @@ impl Default for Model {
             ceremony_description: None,
             ceremony_materials: Vec::new(),
             ceremony_step_count: None,
+            system_info: None,
+            environment: None,
             screen: Screen::Step {
                 tab: StepTab::Overview,
             },
@@ -221,6 +229,10 @@ pub enum StepTab {
     /// Deviations side panel. Reserved for non-log content (operator
     /// notes, attestation summary, etc.) once those land.
     Deviations,
+    /// Environment dashboard: build/host identity header plus the live
+    /// device inventory (disks today; peripherals and network later).
+    /// Situational awareness during the run, not part of the transcript.
+    System,
 }
 
 /// Lifecycle phase of the ceremony as observed by the UI.

--- a/crates/rite-tui/src/preview.rs
+++ b/crates/rite-tui/src/preview.rs
@@ -13,7 +13,10 @@ use ratatui::backend::TestBackend;
 use ratatui::buffer::Buffer;
 
 use rite_model::{MaterialId, Prompt, StepId, ValidatorSpec};
-use rite_runtime::{Icon, MaterialOverview, MaterialOverviewKind, PromptId};
+use rite_runtime::{
+    BackendVersion, BuildInfo, Disk, Environment, HostInfo, Icon, MaterialOverview,
+    MaterialOverviewKind, PromptId, SystemInfo,
+};
 
 use crate::model::{LogLine, Model, PendingPrompt, Screen, StepTab, StepView};
 use crate::view::view;
@@ -151,6 +154,65 @@ fn sample_with_prompt() -> Model {
     m
 }
 
+/// System tab: build/host identity header plus a small disk inventory,
+/// as populated by the `SystemInfo` and `Environment` signals.
+fn sample_system() -> Model {
+    let mut m = sample_running();
+    m.system_info = Some(SystemInfo {
+        build: BuildInfo {
+            version: "0.2.0".to_string(),
+            commit: "a1b2c3d".to_string(),
+            commit_date: "2026-05-20".to_string(),
+            build_date: "2026-05-25".to_string(),
+            target: "aarch64-apple-darwin".to_string(),
+            profile: "release".to_string(),
+            features: "attestation,crypto,openssl,pki,render,verification".to_string(),
+            rustc: "1.95.0".to_string(),
+        },
+        host: HostInfo {
+            arch: "aarch64".to_string(),
+            os: Some("Darwin".to_string()),
+            os_version: Some("macOS 15.4".to_string()),
+            kernel_version: None,
+            hostname: Some("ceremony-air-gap".to_string()),
+            machine_id: None,
+            cpu_model: None,
+            hardening: None,
+        },
+        backends: vec![BackendVersion {
+            provider: "openssl".to_string(),
+            version: "OpenSSL 3.6.2 7 Apr 2026".to_string(),
+            source: Some("system".to_string()),
+        }],
+    });
+    m.environment = Some(Environment {
+        disks: vec![
+            Disk {
+                name: "disk0s1".to_string(),
+                mount_point: "/".to_string(),
+                file_system: Some("apfs".to_string()),
+                total_bytes: 994_662_584_320,
+                available_bytes: 612_339_499_008,
+                removable: false,
+                kind: Some("SSD".to_string()),
+            },
+            Disk {
+                name: "disk4s1".to_string(),
+                mount_point: "/Volumes/CEREMONY".to_string(),
+                file_system: Some("exfat".to_string()),
+                total_bytes: 31_914_983_424,
+                available_bytes: 31_900_000_000,
+                removable: true,
+                kind: None,
+            },
+        ],
+    });
+    m.screen = Screen::Step {
+        tab: StepTab::System,
+    };
+    m
+}
+
 /// Render `model` into a width×height buffer and return its plain-text
 /// dump, one row per line.
 fn render(model: &Model, width: u16, height: u16) -> String {
@@ -229,6 +291,13 @@ fn preview_deviations_tab() {
     };
     let out = render(&m, 100, 24);
     eprintln!("--- deviations tab (100x24) ---\n{out}");
+}
+
+#[test]
+fn preview_system_tab() {
+    let m = sample_system();
+    let out = render(&m, 100, 24);
+    eprintln!("--- system tab (100x24) ---\n{out}");
 }
 
 #[test]

--- a/crates/rite-tui/src/update.rs
+++ b/crates/rite-tui/src/update.rs
@@ -98,7 +98,8 @@ fn handle_key(model: &mut Model, key: KeyEvent) -> Vec<Cmd> {
         *tab = match *tab {
             StepTab::Overview => StepTab::Ceremony,
             StepTab::Ceremony => StepTab::Deviations,
-            StepTab::Deviations => StepTab::Overview,
+            StepTab::Deviations => StepTab::System,
+            StepTab::System => StepTab::Overview,
         };
         return Vec::new();
     }
@@ -469,19 +470,27 @@ fn handle_fact(model: &mut Model, fact: &StepFact) -> Vec<Cmd> {
 }
 
 fn handle_signal(model: &mut Model, signal: &UiSignal) -> Vec<Cmd> {
-    if let UiSignal::CeremonyOverview {
-        description,
-        materials,
-        step_count,
-    } = signal
-    {
-        model.ceremony_description.clone_from(description);
-        model.ceremony_materials.clone_from(materials);
-        model.ceremony_step_count = Some(*step_count);
-        return Vec::new();
-    }
-    if let Some((icon, text)) = signal_summary(signal) {
-        model.push_entry(icon, text);
+    // Exhaustive (no wildcard) so a new UiSignal variant forces a decision
+    // here, matching the protocol's deliberate not-`#[non_exhaustive]` choice.
+    match signal {
+        UiSignal::CeremonyOverview {
+            description,
+            materials,
+            step_count,
+        } => {
+            model.ceremony_description.clone_from(description);
+            model.ceremony_materials.clone_from(materials);
+            model.ceremony_step_count = Some(*step_count);
+        }
+        UiSignal::SystemInfo(info) => model.system_info = Some((**info).clone()),
+        // Re-emittable: a later observer can resend the environment; replace
+        // the whole view each time rather than merging.
+        UiSignal::Environment(env) => model.environment = Some(env.clone()),
+        UiSignal::LogLine { .. } | UiSignal::Progress { .. } => {
+            if let Some((icon, text)) = signal_summary(signal) {
+                model.push_entry(icon, text);
+            }
+        }
     }
     Vec::new()
 }
@@ -602,7 +611,7 @@ mod tests {
 
     #[test]
     fn deviation_key_is_ignored_outside_deviations_tab() {
-        for tab in [StepTab::Overview, StepTab::Ceremony] {
+        for tab in [StepTab::Overview, StepTab::Ceremony, StepTab::System] {
             let mut model = Model::new();
             model.screen = Screen::Step { tab };
             let cmds = update(&mut model, Msg::Key(key(KeyCode::Char('d'))));
@@ -651,7 +660,7 @@ mod tests {
     }
 
     #[test]
-    fn tab_cycles_overview_ceremony_deviations() {
+    fn tab_cycles_overview_ceremony_deviations_system() {
         let mut model = Model::new();
         // Default tab is Overview.
         assert!(matches!(
@@ -672,6 +681,13 @@ mod tests {
             model.screen,
             Screen::Step {
                 tab: StepTab::Deviations
+            }
+        ));
+        let _ = update(&mut model, Msg::Key(key(KeyCode::Tab)));
+        assert!(matches!(
+            model.screen,
+            Screen::Step {
+                tab: StepTab::System
             }
         ));
         let _ = update(&mut model, Msg::Key(key(KeyCode::Tab)));
@@ -720,6 +736,7 @@ mod tests {
         );
         // Operator switches back to Overview to re-read the description.
         let _ = update(&mut model, Msg::Key(key(KeyCode::Tab))); // → Deviations
+        let _ = update(&mut model, Msg::Key(key(KeyCode::Tab))); // → System
         let _ = update(&mut model, Msg::Key(key(KeyCode::Tab))); // → Overview
         assert!(matches!(
             model.screen,

--- a/crates/rite-tui/src/view.rs
+++ b/crates/rite-tui/src/view.rs
@@ -51,7 +51,7 @@ mod theme {
 const SPINNER_FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 /// Tab labels, rendered as a centered pill row.
-const TAB_LABELS: [&str; 3] = [" Overview ", " Ceremony ", " Deviations "];
+const TAB_LABELS: [&str; 4] = [" Overview ", " Ceremony ", " Deviations ", " System "];
 const TAB_DIVIDER: &str = "│";
 
 /// Static glyph for a non-spinner [`Icon`]. The TUI owns its glyph mapping;
@@ -152,6 +152,10 @@ fn render_step_screen(model: &Model, tab: StepTab, frame: &mut Frame<'_>, area: 
             render_deviations(model, frame, content_area);
             model.log_scroll
         }
+        StepTab::System => {
+            render_system(model, frame, content_area);
+            model.log_scroll
+        }
     }
 }
 
@@ -175,6 +179,7 @@ fn render_tabs_row(model: &Model, tab: StepTab, frame: &mut Frame<'_>, area: Rec
         StepTab::Overview => 0,
         StepTab::Ceremony => 1,
         StepTab::Deviations => 2,
+        StepTab::System => 3,
     };
     let mut spans: Vec<Span<'_>> = Vec::with_capacity(TAB_LABELS.len().saturating_mul(2));
     for (i, label) in TAB_LABELS.iter().enumerate() {
@@ -527,6 +532,160 @@ fn render_overview(model: &Model, frame: &mut Frame<'_>, area: Rect) {
     );
 }
 
+/// System tab: a static build/host identity header, then the live device
+/// environment. Situational awareness for the operator during the run; none
+/// of this is recorded to the transcript (the `machine_info` action covers
+/// machine identity as evidence).
+fn render_system(model: &Model, frame: &mut Frame<'_>, area: Rect) {
+    let mut lines: Vec<Line<'_>> = Vec::new();
+
+    if let Some(info) = &model.system_info {
+        lines.push(section_heading("Build"));
+        lines.push(kv_line("rite", &info.build.version));
+        lines.push(kv_line("commit", &info.build.commit));
+        lines.push(kv_line("built", &info.build.build_date));
+        lines.push(kv_line("target", &info.build.target));
+        lines.push(kv_line("profile", &info.build.profile));
+        if !info.build.features.is_empty() {
+            lines.push(kv_line("features", &info.build.features));
+        }
+        lines.push(Line::from(""));
+
+        lines.push(section_heading("Host"));
+        let os = match (&info.host.os, &info.host.os_version) {
+            (Some(os), Some(v)) => format!("{os} ({v})"),
+            (Some(os), None) => os.clone(),
+            (None, _) => "unknown".to_string(),
+        };
+        lines.push(kv_line("os", &os));
+        lines.push(kv_line("arch", &info.host.arch));
+        if let Some(hostname) = &info.host.hostname {
+            lines.push(kv_line("hostname", hostname));
+        }
+        lines.push(Line::from(""));
+
+        lines.push(section_heading("Backends"));
+        if info.backends.is_empty() {
+            lines.push(dim_line("(none linked)"));
+        } else {
+            for backend in &info.backends {
+                let value = match &backend.source {
+                    Some(source) => format!("{} ({source})", backend.version),
+                    None => backend.version.clone(),
+                };
+                lines.push(kv_line(&backend.provider, &value));
+            }
+        }
+        lines.push(Line::from(""));
+    } else {
+        lines.push(dim_line("(system information unavailable)"));
+        lines.push(Line::from(""));
+    }
+
+    lines.push(section_heading("Disks"));
+    match model.environment.as_ref().map(|e| &e.disks) {
+        Some(disks) if !disks.is_empty() => {
+            for disk in disks {
+                lines.extend(disk_lines(disk));
+            }
+        }
+        Some(_) => lines.push(dim_line("(none detected)")),
+        None => lines.push(dim_line("(not yet collected)")),
+    }
+    lines.push(Line::from(""));
+
+    lines.push(section_heading("Peripherals"));
+    lines.push(dim_line("(not yet collected)"));
+    lines.push(Line::from(""));
+    lines.push(section_heading("Network"));
+    lines.push(dim_line("(not yet collected)"));
+
+    frame.render_widget(
+        Paragraph::new(lines)
+            .wrap(Wrap { trim: false })
+            .block(plain_block()),
+        area,
+    );
+}
+
+/// A bold section heading line, styled like the Overview tab's headings.
+fn section_heading(text: &str) -> Line<'static> {
+    Line::from(Span::styled(
+        text.to_string(),
+        theme::title().add_modifier(Modifier::BOLD),
+    ))
+}
+
+/// A dimmed standalone line (placeholders, "none" markers).
+fn dim_line(text: &str) -> Line<'static> {
+    Line::from(Span::styled(text.to_string(), theme::footer()))
+}
+
+/// A `label   value` line: dimmed label in a fixed-width column, value in
+/// body text.
+fn kv_line(label: &str, value: &str) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(format!("{label:<11}"), theme::footer()),
+        Span::styled(value.to_string(), theme::text()),
+    ])
+}
+
+/// Render one disk as a bullet heading plus a dimmed detail line.
+fn disk_lines(disk: &rite_runtime::Disk) -> Vec<Line<'static>> {
+    let mut head = vec![
+        Span::raw("• "),
+        Span::styled(
+            disk.mount_point.clone(),
+            theme::text().add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("  "),
+        Span::styled(disk.name.clone(), theme::footer()),
+    ];
+    if disk.removable {
+        head.push(Span::styled("  · removable", theme::footer()));
+    }
+    let mut detail = format!(
+        "{} free of {}",
+        format_bytes(disk.available_bytes),
+        format_bytes(disk.total_bytes),
+    );
+    if let Some(fs) = &disk.file_system {
+        detail.push_str(" · ");
+        detail.push_str(fs);
+    }
+    if let Some(kind) = &disk.kind {
+        detail.push_str(" · ");
+        detail.push_str(kind);
+    }
+    vec![
+        Line::from(head),
+        Line::from(Span::styled(format!("  {detail}"), theme::footer())),
+    ]
+}
+
+/// Human-readable byte size with binary (1024) units. Explicit thresholds
+/// rather than a divide-and-count loop, to stay clear of the integer
+/// arithmetic and indexing lints.
+#[allow(clippy::cast_precision_loss)]
+fn format_bytes(bytes: u64) -> String {
+    const KIB: u64 = 1 << 10;
+    const MIB: u64 = 1 << 20;
+    const GIB: u64 = 1 << 30;
+    const TIB: u64 = 1 << 40;
+    let scaled = |unit: u64| bytes as f64 / unit as f64;
+    if bytes >= TIB {
+        format!("{:.1} TiB", scaled(TIB))
+    } else if bytes >= GIB {
+        format!("{:.1} GiB", scaled(GIB))
+    } else if bytes >= MIB {
+        format!("{:.1} MiB", scaled(MIB))
+    } else if bytes >= KIB {
+        format!("{:.1} KiB", scaled(KIB))
+    } else {
+        format!("{bytes} B")
+    }
+}
+
 /// Render one material as a heading line plus an optional dimmed
 /// description, so the overview reads as a scannable bulleted list.
 fn material_lines(material: &MaterialOverview) -> Vec<Line<'static>> {
@@ -729,7 +888,8 @@ fn render_footer(model: &Model, frame: &mut Frame<'_>, area: Rect) {
             (StepTab::Ceremony, false) => {
                 "↑/↓ · PgUp/PgDn: scroll  ·  Tab: deviations  ·  Esc: abort"
             }
-            (StepTab::Deviations, _) => "d: log deviation  ·  Tab: overview  ·  Esc: abort",
+            (StepTab::Deviations, _) => "d: log deviation  ·  Tab: system  ·  Esc: abort",
+            (StepTab::System, _) => "Tab: overview  ·  Esc: abort",
         },
     };
     frame.render_widget(Paragraph::new(hint).style(theme::footer()), area);

--- a/docs/development/runtime-and-frontend.md
+++ b/docs/development/runtime-and-frontend.md
@@ -40,6 +40,42 @@ frontend is an [`ExecEvent`]; everything a frontend sends back is a
 | `AwaitPrompt { … }`         | runtime → frontend | no (the answer becomes a fact)               | Block until the operator answers.                                     |
 | `Finalized { fingerprint }` | runtime → frontend | no (out-of-band)                             | Sent after the terminal fact so frontends can display the chain head. |
 
+### Data flow: facts vs signals vs out-of-band evidence
+
+Two questions decide how any piece of information moves through the system:
+*who produces it* (a ceremony action, or the tool gathering something
+ambiently) and *is it evidence* (recorded, or ephemeral). That gives four
+positions:
+
+|                     | Recorded (evidence)                                                                    | Ephemeral (UI only)                                                     |
+|---------------------|----------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
+| **Ceremony-driven** | `StepFact` from an action (`machine_info`, key generation, attestation)                | an action's own `UiSignal` for live step feedback (`Progress`)          |
+| **Tool-driven**     | out-of-band artifact + an anchoring `ArtifactWritten` fact (future background capture) | `UiSignal` (`CeremonyOverview`, `SystemInfo`, `Environment`, `LogLine`) |
+
+Four rules keep this stable as the protocol grows:
+
+1. **Transcript = facts = actions.** Anything auditable is a `StepFact`
+   produced by an action in the plan. The only exception is the runner's own
+   lifecycle facts (`CeremonyStarted` / `CeremonyCompleted` / `CeremonyFailed`
+   and the step/act boundaries): the small core run-metadata set.
+2. **Signals are ephemeral and droppable.** A frontend that ignores every
+   `UiSignal` still produces a correct transcript and outcome (this is why
+   `console` and `headless` ignore most of them). Never make correctness
+   depend on a signal.
+3. **A checkpoint is an action, not a promoted signal.** To put something in
+   the transcript, emit a `StepFact` from an action; it may *also* emit a
+   signal for live display. A signal is never silently promoted into the
+   transcript.
+4. **Background evidence anchors by hash.** Continuous capture (not yet
+   implemented) lives outside the JSONL; the transcript carries only the
+   content-hash fact, sealed at stop time.
+
+`UiSignal` variants fall into three sub-families, so new ones have an obvious
+home: *narration* (`LogLine`, `Progress`), *one-shot structured* (a single
+snapshot at ceremony start, `CeremonyOverview` and `SystemInfo`), and
+*re-emittable structured* (state the runtime may resend during the run;
+`Environment`, which a frontend replaces wholesale on each emission).
+
 ### `StepFact`
 
 Every variant of `StepFact` is what would convince a future auditor that


### PR DESCRIPTION
Surface the runtime environment in a fourth run-TUI tab: rite build metadata, host identity, linked backend versions, and a live disk inventory. This gives operators and witnesses an at-a-glance record of what machine and what build is driving a ceremony.
