### PR TITLE
feat(transcript): single event timestamp on the chain envelope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,7 +1696,6 @@ dependencies = [
 name = "rite-model"
 version = "0.2.2"
 dependencies = [
- "chrono",
  "indexmap",
  "rite-sdk",
  "serde",

--- a/crates/rite-model/Cargo.toml
+++ b/crates/rite-model/Cargo.toml
@@ -16,7 +16,6 @@ rite-sdk = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 indexmap = { workspace = true }
-chrono = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/rite-model/src/transcript.rs
+++ b/crates/rite-model/src/transcript.rs
@@ -12,7 +12,6 @@
 
 use std::path::PathBuf;
 
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::ir::{ActId, RoleId, StepId};
@@ -151,8 +150,6 @@ pub enum StepFact {
     CeremonyStarted {
         /// Ceremony name from the DSL.
         name: String,
-        /// Wall-clock timestamp at start.
-        started_at: DateTime<Utc>,
     },
     /// Beginning of an act (named subdivision of a ceremony).
     ActStarted {
@@ -173,8 +170,6 @@ pub enum StepFact {
         /// Carried alongside the id so transcripts stay self-contained for
         /// reports and verifiers without re-reading the ceremony YAML.
         role_name: String,
-        /// Wall-clock timestamp at start.
-        started_at: DateTime<Utc>,
     },
     /// A prompt has been answered and validated.
     PromptAnswered {
@@ -187,8 +182,6 @@ pub enum StepFact {
         prompt: Prompt,
         /// Redacted response record.
         response: ResponseRecord,
-        /// Wall-clock timestamp when the response was accepted.
-        at: DateTime<Utc>,
     },
     /// A backend operation completed and produced structured evidence.
     BackendOperation {
@@ -211,8 +204,6 @@ pub enum StepFact {
         role: RoleId,
         /// Verbatim attestation statement.
         statement: String,
-        /// Wall-clock timestamp when the attestation was recorded.
-        at: DateTime<Utc>,
     },
     /// An artifact was written to disk.
     ArtifactWritten {
@@ -234,8 +225,6 @@ pub enum StepFact {
         step: Option<StepId>,
         /// Verbatim deviation text.
         text: String,
-        /// Wall-clock timestamp when the deviation was recorded.
-        at: DateTime<Utc>,
     },
     /// Step finished executing.
     StepCompleted {
@@ -243,8 +232,6 @@ pub enum StepFact {
         id: StepId,
         /// Outcome (completed or skipped).
         outcome: StepOutcome,
-        /// Wall-clock timestamp at completion.
-        completed_at: DateTime<Utc>,
     },
     /// Ceremony finished successfully.
     ///
@@ -252,16 +239,11 @@ pub enum StepFact {
     /// for this line, recoverable by any reader, so the fact itself
     /// carries no fingerprint field. The runtime forwards the value to
     /// frontends through an out-of-band channel event.
-    CeremonyCompleted {
-        /// Wall-clock timestamp at completion.
-        completed_at: DateTime<Utc>,
-    },
+    CeremonyCompleted {},
     /// Ceremony failed or was aborted.
     CeremonyFailed {
         /// Structured error record.
         error: ErrorRecord,
-        /// Wall-clock timestamp at failure.
-        failed_at: DateTime<Utc>,
     },
     /// The ceremony entropy source was seeded with machine randomness.
     ///
@@ -270,9 +252,7 @@ pub enum StepFact {
     /// value the ceremony later draws is re-derivable from the transcript
     /// alone. Part of the [entropy source](StepFact::EntropyDrawn) family.
     ///
-    /// Carries no timestamp of its own: it is emitted immediately after
-    /// [`CeremonyStarted`](StepFact::CeremonyStarted), whose `started_at`
-    /// stamps that instant.
+    /// Like every fact, it is timed by the `at` on its chain envelope.
     EntropySeeded {
         /// Lowercase hex of the gathered machine entropy `m`.
         m: String,
@@ -329,12 +309,7 @@ pub enum StepFact {
 #[cfg(test)]
 mod schema_snapshot_tests {
     use super::*;
-    use chrono::TimeZone;
     use serde_json::json;
-
-    fn ts() -> DateTime<Utc> {
-        Utc.with_ymd_and_hms(2026, 1, 2, 3, 4, 5).unwrap()
-    }
 
     fn assert_json(fact: &StepFact, expected: &serde_json::Value) {
         let actual = serde_json::to_value(fact).expect("serialize StepFact");
@@ -346,12 +321,10 @@ mod schema_snapshot_tests {
         assert_json(
             &StepFact::CeremonyStarted {
                 name: "Root CA".to_string(),
-                started_at: ts(),
             },
             &json!({
                 "type": "ceremony_started",
                 "name": "Root CA",
-                "started_at": "2026-01-02T03:04:05Z",
             }),
         );
     }
@@ -379,7 +352,6 @@ mod schema_snapshot_tests {
                 label: "2.1".to_string(),
                 role: RoleId::new("crypto_officer"),
                 role_name: "Crypto Officer".to_string(),
-                started_at: ts(),
             },
             &json!({
                 "type": "step_started",
@@ -387,7 +359,6 @@ mod schema_snapshot_tests {
                 "label": "2.1",
                 "role": "crypto_officer",
                 "role_name": "Crypto Officer",
-                "started_at": "2026-01-02T03:04:05Z",
             }),
         );
     }
@@ -402,14 +373,12 @@ mod schema_snapshot_tests {
                     default: Some(true),
                 },
                 response: ResponseRecord::Bool { value: true },
-                at: ts(),
             },
             &json!({
                 "type": "prompt_answered",
                 "step": "s1",
                 "prompt": { "type": "confirm", "question": "Proceed?", "default": true },
                 "response": { "type": "bool", "value": true },
-                "at": "2026-01-02T03:04:05Z",
             }),
         );
     }
@@ -426,7 +395,6 @@ mod schema_snapshot_tests {
                 response: ResponseRecord::Text {
                     value: "Alice".to_string(),
                 },
-                at: ts(),
             },
             &json!({
                 "type": "prompt_answered",
@@ -437,7 +405,6 @@ mod schema_snapshot_tests {
                     "validator": { "kind": "non_empty" },
                 },
                 "response": { "type": "text", "value": "Alice" },
-                "at": "2026-01-02T03:04:05Z",
             }),
         );
     }
@@ -454,7 +421,6 @@ mod schema_snapshot_tests {
                 response: ResponseRecord::Text {
                     value: "AB12".to_string(),
                 },
-                at: ts(),
             },
             &json!({
                 "type": "prompt_answered",
@@ -465,7 +431,6 @@ mod schema_snapshot_tests {
                     "validator": { "kind": "regex", "value": "^[A-Z0-9]+$" },
                 },
                 "response": { "type": "text", "value": "AB12" },
-                "at": "2026-01-02T03:04:05Z",
             }),
         );
     }
@@ -482,7 +447,6 @@ mod schema_snapshot_tests {
                 response: ResponseRecord::Text {
                     value: "ABCD".to_string(),
                 },
-                at: ts(),
             },
             &json!({
                 "type": "prompt_answered",
@@ -493,7 +457,6 @@ mod schema_snapshot_tests {
                     "validator": { "kind": "predefined", "value": "serial_number" },
                 },
                 "response": { "type": "text", "value": "ABCD" },
-                "at": "2026-01-02T03:04:05Z",
             }),
         );
     }
@@ -509,7 +472,6 @@ mod schema_snapshot_tests {
                 response: ResponseRecord::SecretRedacted {
                     sha256_of_plaintext: "f".repeat(64),
                 },
-                at: ts(),
             },
             &json!({
                 "type": "prompt_answered",
@@ -519,7 +481,6 @@ mod schema_snapshot_tests {
                     "type": "secret_redacted",
                     "sha256_of_plaintext": "f".repeat(64),
                 },
-                "at": "2026-01-02T03:04:05Z",
             }),
         );
     }
@@ -536,14 +497,12 @@ mod schema_snapshot_tests {
                 response: ResponseRecord::Text {
                     value: "attest".to_string(),
                 },
-                at: ts(),
             },
             &json!({
                 "type": "prompt_answered",
                 "step": "s1",
                 "prompt": { "type": "literal", "label": "Type 'attest'", "expected": "attest" },
                 "response": { "type": "text", "value": "attest" },
-                "at": "2026-01-02T03:04:05Z",
             }),
         );
     }
@@ -557,14 +516,12 @@ mod schema_snapshot_tests {
                     hint: Some("Press Enter".to_string()),
                 },
                 response: ResponseRecord::Acknowledged,
-                at: ts(),
             },
             &json!({
                 "type": "prompt_answered",
                 "step": "s1",
                 "prompt": { "type": "continue", "hint": "Press Enter" },
                 "response": { "type": "acknowledged" },
-                "at": "2026-01-02T03:04:05Z",
             }),
         );
     }
@@ -597,14 +554,12 @@ mod schema_snapshot_tests {
                 step: StepId::new("s1"),
                 role: RoleId::new("crypto_officer"),
                 statement: "I confirm.".to_string(),
-                at: ts(),
             },
             &json!({
                 "type": "attestation_recorded",
                 "step": "s1",
                 "role": "crypto_officer",
                 "statement": "I confirm.",
-                "at": "2026-01-02T03:04:05Z",
             }),
         );
     }
@@ -634,13 +589,11 @@ mod schema_snapshot_tests {
             &StepFact::DeviationRecorded {
                 step: Some(StepId::new("s1")),
                 text: "phone rang".to_string(),
-                at: ts(),
             },
             &json!({
                 "type": "deviation_recorded",
                 "step": "s1",
                 "text": "phone rang",
-                "at": "2026-01-02T03:04:05Z",
             }),
         );
     }
@@ -653,13 +606,11 @@ mod schema_snapshot_tests {
                 outcome: StepOutcome::Completed {
                     message: "done".to_string(),
                 },
-                completed_at: ts(),
             },
             &json!({
                 "type": "step_completed",
                 "id": "s1",
                 "outcome": { "status": "completed", "message": "done" },
-                "completed_at": "2026-01-02T03:04:05Z",
             }),
         );
     }
@@ -667,10 +618,9 @@ mod schema_snapshot_tests {
     #[test]
     fn ceremony_completed() {
         assert_json(
-            &StepFact::CeremonyCompleted { completed_at: ts() },
+            &StepFact::CeremonyCompleted {},
             &json!({
                 "type": "ceremony_completed",
-                "completed_at": "2026-01-02T03:04:05Z",
             }),
         );
     }
@@ -680,12 +630,10 @@ mod schema_snapshot_tests {
         assert_json(
             &StepFact::CeremonyFailed {
                 error: ErrorRecord::new("aborted", "ceremony aborted by operator"),
-                failed_at: ts(),
             },
             &json!({
                 "type": "ceremony_failed",
                 "error": { "kind": "aborted", "message": "ceremony aborted by operator" },
-                "failed_at": "2026-01-02T03:04:05Z",
             }),
         );
     }

--- a/crates/rite-render/src/report/data.rs
+++ b/crates/rite-render/src/report/data.rs
@@ -108,10 +108,13 @@ pub struct ReportDeviation {
 /// `transcript_fingerprint` is expected to come from the same call to
 /// the runtime's `read_verified_transcript` that produced `facts`.
 #[must_use]
-pub fn build_report_data(facts: &[StepFact], transcript_fingerprint: &str) -> ReportData {
+pub fn build_report_data<'a>(
+    facts: impl IntoIterator<Item = (DateTime<Utc>, &'a StepFact)>,
+    transcript_fingerprint: &str,
+) -> ReportData {
     let mut builder = Builder::new(transcript_fingerprint.to_string());
-    for fact in facts {
-        builder.ingest(fact);
+    for (at, fact) in facts {
+        builder.ingest(at, fact);
     }
     builder.finish()
 }
@@ -145,19 +148,16 @@ impl Builder {
         }
     }
 
-    fn ingest(&mut self, fact: &StepFact) {
+    fn ingest(&mut self, at: DateTime<Utc>, fact: &StepFact) {
         match fact {
-            StepFact::CeremonyStarted {
-                name, started_at, ..
-            } => {
+            StepFact::CeremonyStarted { name, .. } => {
                 self.ceremony_name.clone_from(name);
-                self.started_at = Some(*started_at);
+                self.started_at = Some(at);
             }
             StepFact::StepStarted {
                 id,
                 label,
                 role_name,
-                started_at,
                 ..
             } => {
                 let step_id = id.as_str().to_string();
@@ -166,23 +166,19 @@ impl Builder {
                     step_id,
                     label: label.clone(),
                     role: role_name.clone(),
-                    started_at: *started_at,
+                    started_at: at,
                     completed_at: None,
                     outcome_status: "in_progress".to_string(),
                     outcome_message: None,
                 });
             }
-            StepFact::StepCompleted {
-                id,
-                outcome,
-                completed_at,
-            } => {
+            StepFact::StepCompleted { id, outcome } => {
                 if let Some(step) = self
                     .step_index
                     .get(id.as_str())
                     .and_then(|i| self.steps.get_mut(*i))
                 {
-                    step.completed_at = Some(*completed_at);
+                    step.completed_at = Some(at);
                     let (status, message) = describe_outcome(outcome);
                     step.outcome_status = status;
                     step.outcome_message = message;
@@ -201,23 +197,23 @@ impl Builder {
                     sha256: sha256.clone(),
                 });
             }
-            StepFact::DeviationRecorded { step, text, at } => {
+            StepFact::DeviationRecorded { step, text } => {
                 self.deviations.push(ReportDeviation {
                     step_id: step
                         .as_ref()
                         .map(|s| s.as_str().to_string())
                         .unwrap_or_default(),
                     text: text.clone(),
-                    recorded_at: *at,
+                    recorded_at: at,
                 });
             }
-            StepFact::CeremonyCompleted { completed_at, .. } => {
+            StepFact::CeremonyCompleted {} => {
                 self.status = ReportStatus::Completed;
-                self.completed_at = Some(*completed_at);
+                self.completed_at = Some(at);
             }
-            StepFact::CeremonyFailed { error, failed_at } => {
+            StepFact::CeremonyFailed { error } => {
                 self.status = ReportStatus::Failed;
-                self.completed_at = Some(*failed_at);
+                self.completed_at = Some(at);
                 self.failure = Some(ReportFailure {
                     kind: error.kind.clone(),
                     message: error.message.clone(),

--- a/crates/rite-render/tests/render.rs
+++ b/crates/rite-render/tests/render.rs
@@ -79,7 +79,10 @@ fn long_instructions_render_as_paragraphs_and_bullets() {
 
 #[test]
 fn report_renders() {
-    let data = rite_render::report::build_report_data(&[], "sha256:deadbeef");
+    let data = rite_render::report::build_report_data(
+        std::iter::empty::<(chrono::DateTime<chrono::Utc>, &rite_model::StepFact)>(),
+        "sha256:deadbeef",
+    );
     let html = render_report(&data, &Branding::default(), Theme::Formal).unwrap();
     assert!(html.starts_with("<!DOCTYPE html>"));
     assert!(html.contains("Ceremony Report"));

--- a/crates/rite-runtime/src/clock.rs
+++ b/crates/rite-runtime/src/clock.rs
@@ -1,0 +1,31 @@
+//! The ceremony clock: the single source of wall-clock time for the run.
+//!
+//! Event time is part of the hashed transcript line, so it is audit evidence.
+//! It is owned by the executor (the authority on what happened), not by the
+//! transcript sink (a swappable persistence detail): the same `at` the sink
+//! writes is the `at` the live frontend sees, and it does not change if the
+//! storage backend changes. Reading the clock is the one nondeterministic input
+//! in the record path, so it lives behind this trait and can be faked in tests.
+
+use chrono::{DateTime, Utc};
+
+/// Source of wall-clock time for a ceremony run.
+///
+/// Implementations must be cheap to call (read once per emitted fact) and
+/// thread-safe: the executor runs on its own thread and shares the clock with
+/// the [`Reporter`](crate::Reporter).
+pub trait Clock: Send + Sync {
+    /// The current instant, in UTC.
+    fn now(&self) -> DateTime<Utc>;
+}
+
+/// The real clock: reads the host wall clock via [`Utc::now`]. The default for
+/// every production run.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+}

--- a/crates/rite-runtime/src/lib.rs
+++ b/crates/rite-runtime/src/lib.rs
@@ -23,6 +23,7 @@
 mod actions;
 mod artifact_resolver;
 mod backend;
+mod clock;
 mod display;
 mod entropy;
 mod executor;
@@ -46,6 +47,8 @@ pub use actions::{ActionCategory, ActionMetadata, ArtifactValue, KeyFormat};
 
 // Backend registry (traits live in `rite-sdk`, not here)
 pub use backend::{BackendFactory, BackendRegistry};
+
+pub use clock::{Clock, SystemClock};
 
 // Channel vocabulary for the runtime ↔ frontend boundary.
 // Persisted transcript types (`StepFact`, `Prompt`, `ResponseRecord`, …)

--- a/crates/rite-runtime/src/protocol.rs
+++ b/crates/rite-runtime/src/protocol.rs
@@ -13,6 +13,7 @@
 //!   converted to [`rite_model::ResponseRecord`] when persisted)
 //! - [`UiSignal`], [`Icon`], UI narration, never on disk
 
+use chrono::{DateTime, Utc};
 use rite_model::{Material, MaterialId, MaterialKind, Prompt, StepFact, StepId};
 use secrecy::SecretString;
 
@@ -239,7 +240,15 @@ pub enum UiSignal {
 pub enum ExecEvent {
     /// A transcript-worthy fact. Already persisted by the transcript sink
     /// by the time it reaches the frontend.
-    Fact(StepFact),
+    Fact {
+        /// Event time, stamped from the executor's clock when the fact was
+        /// emitted, the same `at` recorded on the transcript envelope. Frontends
+        /// display this rather than their own receipt time, so live timestamps
+        /// match the audit record.
+        at: DateTime<Utc>,
+        /// The fact itself.
+        fact: StepFact,
+    },
     /// A UI-only signal.
     Signal(UiSignal),
     /// The runtime is waiting for a user response. The frontend must reply

--- a/crates/rite-runtime/src/reporter.rs
+++ b/crates/rite-runtime/src/reporter.rs
@@ -23,12 +23,14 @@
 //! arrive, so deviations are recorded with no lag and abort interrupts
 //! the prompt cleanly.
 
-use chrono::Utc;
+use std::sync::Arc;
+
 use crossbeam_channel::{Receiver, Sender, TryRecvError};
 use rite_model::{ErrorRecord, Prompt, ResponseRecord, StepFact, StepId};
 use secrecy::ExposeSecret;
 use thiserror::Error;
 
+use crate::clock::Clock;
 use crate::entropy::CeremonyRandom;
 use crate::protocol::{ExecEvent, Icon, PromptId, Response, UiCommand, UiSignal};
 use crate::transcript::sha256_hex;
@@ -96,14 +98,18 @@ pub struct Reporter<'a> {
     /// ceremony start; a draw before then is an internal ordering bug and fails
     /// loudly rather than deriving from a stand-in seed.
     random: Option<CeremonyRandom>,
+    /// The run clock. Read once per fact in [`Reporter::fact`] to stamp the
+    /// event time onto both the transcript line and the live UI event.
+    clock: Arc<dyn Clock>,
 }
 
 impl<'a> Reporter<'a> {
-    /// Build a reporter bound to the given channels and transcript sink.
+    /// Build a reporter bound to the given channels, transcript sink, and clock.
     pub fn new(
         event_tx: &'a Sender<ExecEvent>,
         cmd_rx: &'a Receiver<UiCommand>,
         transcript: &'a mut dyn TranscriptSink,
+        clock: Arc<dyn Clock>,
     ) -> Self {
         Self {
             event_tx,
@@ -112,6 +118,7 @@ impl<'a> Reporter<'a> {
             next_prompt_id: 0,
             current_step: None,
             random: None,
+            clock,
         }
     }
 
@@ -151,9 +158,12 @@ impl<'a> Reporter<'a> {
     /// Returns [`ReporterError::Transcript`] if the sink fails to persist,
     /// or [`ReporterError::Disconnected`] if the frontend is gone.
     pub fn fact(&mut self, fact: StepFact) -> Result<(), ReporterError> {
-        self.transcript.record(&fact)?;
+        // Stamp the event time once, from the run clock, and use it for both
+        // the durable record and the live UI event so they never disagree.
+        let at = self.clock.now();
+        self.transcript.record(at, &fact)?;
         self.event_tx
-            .send(ExecEvent::Fact(fact))
+            .send(ExecEvent::Fact { at, fact })
             .map_err(|_| ReporterError::Disconnected)?;
         Ok(())
     }
@@ -362,7 +372,6 @@ impl<'a> Reporter<'a> {
                                     step: step.clone(),
                                     prompt: prompt.clone(),
                                     response: record,
-                                    at: Utc::now(),
                                 })?;
                                 return Ok(response);
                             }
@@ -397,11 +406,7 @@ impl<'a> Reporter<'a> {
     }
 
     fn emit_deviation(&mut self, step: Option<StepId>, text: String) -> Result<(), ReporterError> {
-        self.fact(StepFact::DeviationRecorded {
-            step,
-            text,
-            at: Utc::now(),
-        })
+        self.fact(StepFact::DeviationRecorded { step, text })
     }
 }
 
@@ -481,6 +486,7 @@ mod tests {
     use secrecy::SecretString;
 
     use super::*;
+    use crate::clock::SystemClock;
     use crate::transcript_sink::InMemorySink;
     use rite_model::ValidatorSpec;
 
@@ -488,25 +494,54 @@ mod tests {
         StepId::new(step)
     }
 
+    fn test_clock() -> Arc<dyn Clock> {
+        Arc::new(SystemClock)
+    }
+
+    #[test]
+    fn fact_stamps_event_from_the_injected_clock() {
+        use crate::test_support::{FixedClock, fixed_test_time};
+
+        let (event_tx, event_rx) = unbounded();
+        let (_cmd_tx, cmd_rx) = unbounded::<UiCommand>();
+        let mut sink = InMemorySink::new();
+        let fixed = fixed_test_time();
+        let mut reporter =
+            Reporter::new(&event_tx, &cmd_rx, &mut sink, Arc::new(FixedClock(fixed)));
+
+        reporter
+            .fact(StepFact::CeremonyStarted {
+                name: "T".to_string(),
+            })
+            .expect("fact");
+
+        match event_rx.recv().expect("event") {
+            ExecEvent::Fact { at, .. } => assert_eq!(at, fixed),
+            other => panic!("expected Fact, got {other:?}"),
+        }
+    }
+
     #[test]
     fn fact_writes_to_sink_and_forwards_to_ui() {
         let (event_tx, event_rx) = unbounded();
         let (_cmd_tx, cmd_rx) = unbounded::<UiCommand>();
         let mut sink = InMemorySink::new();
-        let mut reporter = Reporter::new(&event_tx, &cmd_rx, &mut sink);
+        let mut reporter = Reporter::new(&event_tx, &cmd_rx, &mut sink, test_clock());
         reporter.set_current_step(Some(ids("s1")));
 
         reporter
             .fact(StepFact::DeviationRecorded {
                 step: Some(ids("s1")),
                 text: "minor".to_string(),
-                at: Utc::now(),
             })
             .expect("emit fact");
 
         assert_eq!(sink.len(), 1);
         match event_rx.try_recv().expect("ui event") {
-            ExecEvent::Fact(StepFact::DeviationRecorded { text, .. }) => {
+            ExecEvent::Fact {
+                fact: StepFact::DeviationRecorded { text, .. },
+                ..
+            } => {
                 assert_eq!(text, "minor");
             }
             other => panic!("unexpected event: {other:?}"),
@@ -518,7 +553,7 @@ mod tests {
         let (event_tx, event_rx) = unbounded();
         let (_cmd_tx, cmd_rx) = unbounded::<UiCommand>();
         let mut sink = InMemorySink::new();
-        let mut reporter = Reporter::new(&event_tx, &cmd_rx, &mut sink);
+        let mut reporter = Reporter::new(&event_tx, &cmd_rx, &mut sink, test_clock());
         reporter.set_current_step(Some(ids("s1")));
 
         reporter.log(Icon::Info, "hello").expect("log");
@@ -535,7 +570,7 @@ mod tests {
         let (event_tx, _event_rx) = unbounded::<ExecEvent>();
         let (cmd_tx, cmd_rx) = unbounded();
         let mut sink = InMemorySink::new();
-        let mut reporter = Reporter::new(&event_tx, &cmd_rx, &mut sink);
+        let mut reporter = Reporter::new(&event_tx, &cmd_rx, &mut sink, test_clock());
         reporter.set_current_step(Some(ids("s1")));
 
         cmd_tx.send(UiCommand::Abort).expect("send");
@@ -548,7 +583,7 @@ mod tests {
         let (event_tx, event_rx) = unbounded();
         let (cmd_tx, cmd_rx) = unbounded();
         let mut sink = InMemorySink::new();
-        let mut reporter = Reporter::new(&event_tx, &cmd_rx, &mut sink);
+        let mut reporter = Reporter::new(&event_tx, &cmd_rx, &mut sink, test_clock());
         reporter.set_current_step(Some(ids("s1")));
 
         cmd_tx
@@ -560,7 +595,10 @@ mod tests {
 
         assert_eq!(sink.len(), 1);
         match event_rx.try_recv().expect("ui event") {
-            ExecEvent::Fact(StepFact::DeviationRecorded { text, .. }) => {
+            ExecEvent::Fact {
+                fact: StepFact::DeviationRecorded { text, .. },
+                ..
+            } => {
                 assert_eq!(text, "phone rang");
             }
             other => panic!("unexpected event: {other:?}"),
@@ -621,7 +659,7 @@ mod tests {
         let (event_tx, event_rx) = unbounded();
         let (cmd_tx, cmd_rx) = unbounded();
         let mut sink = InMemorySink::new();
-        let mut reporter = Reporter::new(&event_tx, &cmd_rx, &mut sink);
+        let mut reporter = Reporter::new(&event_tx, &cmd_rx, &mut sink, test_clock());
         reporter.set_current_step(Some(ids("s1")));
 
         let frontend = spawn_frontend(event_rx, cmd_tx, |prompt_id, _, tx| {
@@ -654,7 +692,7 @@ mod tests {
         let (event_tx, event_rx) = unbounded();
         let (cmd_tx, cmd_rx) = unbounded();
         let mut sink = InMemorySink::new();
-        let mut reporter = Reporter::new(&event_tx, &cmd_rx, &mut sink);
+        let mut reporter = Reporter::new(&event_tx, &cmd_rx, &mut sink, test_clock());
         reporter.set_current_step(Some(ids("s1")));
 
         let frontend = spawn_frontend(event_rx, cmd_tx, |prompt_id, _, tx| {
@@ -693,7 +731,7 @@ mod tests {
         let (event_tx, event_rx) = unbounded();
         let (cmd_tx, cmd_rx) = unbounded();
         let mut sink = InMemorySink::new();
-        let mut reporter = Reporter::new(&event_tx, &cmd_rx, &mut sink);
+        let mut reporter = Reporter::new(&event_tx, &cmd_rx, &mut sink, test_clock());
         reporter.set_current_step(Some(ids("s1")));
 
         let frontend = spawn_frontend(event_rx, cmd_tx, |prompt_id, _, tx| {
@@ -813,7 +851,7 @@ mod tests {
         let (event_tx, event_rx) = unbounded();
         let (cmd_tx, cmd_rx) = unbounded();
         let mut sink = InMemorySink::new();
-        let mut reporter = Reporter::new(&event_tx, &cmd_rx, &mut sink);
+        let mut reporter = Reporter::new(&event_tx, &cmd_rx, &mut sink, test_clock());
         reporter.set_current_step(Some(ids("s1")));
 
         // Frontend: first AwaitPrompt → reply empty (rejected by validator),

--- a/crates/rite-runtime/src/runner.rs
+++ b/crates/rite-runtime/src/runner.rs
@@ -34,7 +34,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use chrono::Utc;
 use crossbeam_channel::{Receiver, Sender};
 use rand::TryRng;
 use rand::rngs::SysRng;
@@ -44,6 +43,7 @@ use thiserror::Error;
 
 use crate::actions::ActionMetadata;
 use crate::backend::BackendRegistry;
+use crate::clock::{Clock, SystemClock};
 use crate::entropy::DERIVATION_V1;
 use crate::executor::{
     ExecutionError, load_material_artifact, step_info_from, write_artifact_to_disk,
@@ -238,6 +238,7 @@ pub struct Executor {
     output_config: OutputConfig,
     dry_run: bool,
     startup: StartupSnapshot,
+    clock: Arc<dyn Clock>,
 }
 
 impl Executor {
@@ -262,7 +263,16 @@ impl Executor {
             output_config,
             dry_run,
             startup,
+            clock: Arc::new(SystemClock),
         }
+    }
+
+    /// Override the run clock. The default is [`SystemClock`]; tests inject a
+    /// fixed or stepping clock to make recorded event times deterministic.
+    #[must_use]
+    pub fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = clock;
+        self
     }
 
     /// Drive the ceremony to completion.
@@ -307,7 +317,15 @@ impl Executor {
             .collect();
 
         let ceremony_name = self.ceremony.metadata.name.clone();
-        let mut reporter = Reporter::new(event_tx, cmd_rx, transcript_sink.as_mut());
+        // Keep a clock handle for the terminal facts below: `execute_inner`
+        // consumes `self`, so the reporter and the runner share this clone.
+        let clock = Arc::clone(&self.clock);
+        let mut reporter = Reporter::new(
+            event_tx,
+            cmd_rx,
+            transcript_sink.as_mut(),
+            Arc::clone(&clock),
+        );
 
         let outcome = self.execute_inner(&mut reporter, resolved_params, roles, materials_map);
 
@@ -317,13 +335,15 @@ impl Executor {
         // fingerprint to the UI.
         match outcome {
             Ok(counts) => {
-                let completed = StepFact::CeremonyCompleted {
-                    completed_at: Utc::now(),
-                };
+                let at = clock.now();
+                let completed = StepFact::CeremonyCompleted {};
                 transcript_sink
-                    .record(&completed)
+                    .record(at, &completed)
                     .map_err(|e| ExecutionError::TranscriptError(e.to_string()))?;
-                let _ = event_tx.send(ExecEvent::Fact(completed));
+                let _ = event_tx.send(ExecEvent::Fact {
+                    at,
+                    fact: completed,
+                });
                 let fingerprint = transcript_sink
                     .finalize()
                     .map_err(|e| ExecutionError::TranscriptError(e.to_string()))?;
@@ -337,13 +357,11 @@ impl Executor {
                 })
             }
             Err(err) => {
+                let at = clock.now();
                 let record = err.to_error_record();
-                let failed = StepFact::CeremonyFailed {
-                    error: record,
-                    failed_at: Utc::now(),
-                };
-                let _ = transcript_sink.record(&failed);
-                let _ = event_tx.send(ExecEvent::Fact(failed));
+                let failed = StepFact::CeremonyFailed { error: record };
+                let _ = transcript_sink.record(at, &failed);
+                let _ = event_tx.send(ExecEvent::Fact { at, fact: failed });
                 if let Ok(fingerprint) = transcript_sink.finalize() {
                     let _ = event_tx.send(ExecEvent::Finalized {
                         fingerprint: fingerprint.as_str().to_string(),
@@ -366,7 +384,6 @@ impl Executor {
 
         reporter.fact(StepFact::CeremonyStarted {
             name: self.ceremony.metadata.name.clone(),
-            started_at: Utc::now(),
         })?;
 
         // Establish the ceremony entropy source before any step can draw from
@@ -455,7 +472,6 @@ impl Executor {
             }
 
             reporter.set_current_step(Some(step.id.clone()));
-            let started_at = Utc::now();
             let role_id = step.role.clone().unwrap_or_else(|| RoleId::new(""));
             let role_name = self
                 .ceremony
@@ -467,7 +483,6 @@ impl Executor {
                 label: step.step_label.clone(),
                 role: role_id,
                 role_name,
-                started_at,
             })?;
 
             // Pacing: gate the step body on operator acknowledgement. The
@@ -521,13 +536,10 @@ impl Executor {
                     },
                 })?;
 
-            let completed_at = Utc::now();
-
             // StepCompleted
             reporter.fact(StepFact::StepCompleted {
                 id: step.id.clone(),
                 outcome: result.outcome.clone(),
-                completed_at,
             })?;
 
             if let StepOutcome::Completed { .. } = &result.outcome {
@@ -718,7 +730,7 @@ sections:
         // Drain events. With silent=true and dry_run=true, no prompts fire.
         let mut facts = Vec::new();
         while let Ok(ev) = event_rx.recv() {
-            if let ExecEvent::Fact(fact) = ev {
+            if let ExecEvent::Fact { fact, .. } = ev {
                 facts.push(fact);
             }
         }
@@ -737,6 +749,46 @@ sections:
                 "ceremony_completed",
             ],
         );
+
+        drop(cmd_tx);
+    }
+
+    #[test]
+    fn run_stamps_every_fact_from_the_injected_clock() {
+        use crate::test_support::{FixedClock, fixed_test_time};
+
+        let mut registry = ActionRegistry::new();
+        registry.register(Arc::new(PingAction));
+
+        let (cmd_tx, cmd_rx) = unbounded::<UiCommand>();
+        let (event_tx, event_rx) = unbounded::<ExecEvent>();
+        let sink: Box<dyn TranscriptSink> = Box::new(InMemorySink::new());
+
+        let fixed = fixed_test_time();
+        let executor = Executor::new(
+            minimal_ceremony(),
+            registry,
+            BackendRegistry::new(),
+            dry_run_output_config(),
+            true,
+            StartupSnapshot::placeholder(),
+        )
+        .with_clock(Arc::new(FixedClock(fixed)));
+
+        let join = std::thread::spawn(move || executor.run(&cmd_rx, &event_tx, sink));
+
+        let mut times = Vec::new();
+        while let Ok(ev) = event_rx.recv() {
+            if let ExecEvent::Fact { at, .. } = ev {
+                times.push(at);
+            }
+        }
+        join.join().expect("executor join").expect("run ok");
+
+        // Every fact carries the injected time, including the terminal
+        // `ceremony_completed`, which the runner emits outside `reporter.fact`.
+        assert!(!times.is_empty());
+        assert!(times.iter().all(|&t| t == fixed));
 
         drop(cmd_tx);
     }
@@ -804,16 +856,28 @@ sections:
                 let mut trace = Vec::new();
                 while let Ok(event) = event_rx.recv() {
                     match event {
-                        ExecEvent::Fact(StepFact::CeremonyStarted { .. }) => {
+                        ExecEvent::Fact {
+                            fact: StepFact::CeremonyStarted { .. },
+                            ..
+                        } => {
                             trace.push(PacingTrace::CeremonyStarted);
                         }
-                        ExecEvent::Fact(StepFact::StepStarted { label, .. }) => {
+                        ExecEvent::Fact {
+                            fact: StepFact::StepStarted { label, .. },
+                            ..
+                        } => {
                             trace.push(PacingTrace::StepStarted(label));
                         }
-                        ExecEvent::Fact(StepFact::StepCompleted { .. }) => {
+                        ExecEvent::Fact {
+                            fact: StepFact::StepCompleted { .. },
+                            ..
+                        } => {
                             trace.push(PacingTrace::StepCompleted);
                         }
-                        ExecEvent::Fact(StepFact::CeremonyCompleted { .. }) => {
+                        ExecEvent::Fact {
+                            fact: StepFact::CeremonyCompleted { .. },
+                            ..
+                        } => {
                             trace.push(PacingTrace::CeremonyCompleted);
                         }
                         ExecEvent::AwaitPrompt {
@@ -932,7 +996,11 @@ sections:
 
         let mut got_failed = false;
         while let Ok(ev) = event_rx.recv() {
-            if let ExecEvent::Fact(StepFact::CeremonyFailed { error, .. }) = ev {
+            if let ExecEvent::Fact {
+                fact: StepFact::CeremonyFailed { error, .. },
+                ..
+            } = ev
+            {
                 assert_eq!(error.kind, "aborted");
                 got_failed = true;
             }

--- a/crates/rite-runtime/src/test_support.rs
+++ b/crates/rite-runtime/src/test_support.rs
@@ -5,9 +5,13 @@
 //! [`Reporter`] in unit and integration tests, so downstream crates can
 //! exercise their actions without dealing with channel plumbing.
 
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use rite_model::StepId;
 
+use crate::clock::{Clock, SystemClock};
 use crate::protocol::{ExecEvent, UiCommand};
 use crate::reporter::Reporter;
 use crate::transcript_sink::InMemorySink;
@@ -49,7 +53,12 @@ impl ReporterHarness {
     /// box. Tests that need a specific seed can call
     /// [`Reporter::seed_entropy`] again.
     pub fn reporter(&mut self, step: StepId) -> Reporter<'_> {
-        let mut reporter = Reporter::new(&self.event_tx, &self.cmd_rx, &mut self.sink);
+        let mut reporter = Reporter::new(
+            &self.event_tx,
+            &self.cmd_rx,
+            &mut self.sink,
+            Arc::new(SystemClock),
+        );
         reporter.set_current_step(Some(step));
         reporter.seed_entropy(b"rite-test-harness-seed");
         reporter
@@ -65,5 +74,34 @@ impl ReporterHarness {
 impl Default for ReporterHarness {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// A fixed instant for tests that need a deterministic event time. Arbitrary
+/// but stable, so recorded `at` values and snapshots stay reproducible.
+#[must_use]
+pub fn fixed_test_time() -> DateTime<Utc> {
+    // `from_timestamp_nanos` is infallible, unlike the seconds-based
+    // constructor, so this needs no `expect` in non-test library code.
+    DateTime::from_timestamp_nanos(1_700_000_000_000_000_000)
+}
+
+/// Wrap a fact into an [`ExecEvent::Fact`] stamped with [`fixed_test_time`],
+/// for frontend tests that feed synthetic events into a driver.
+#[must_use]
+pub fn fact_event(fact: StepFact) -> ExecEvent {
+    ExecEvent::Fact {
+        at: fixed_test_time(),
+        fact,
+    }
+}
+
+/// A [`Clock`](crate::Clock) frozen at a caller-chosen instant, for asserting
+/// that event times come from the injected clock rather than the wall clock.
+pub struct FixedClock(pub DateTime<Utc>);
+
+impl Clock for FixedClock {
+    fn now(&self) -> DateTime<Utc> {
+        self.0
     }
 }

--- a/crates/rite-runtime/src/transcript_sink.rs
+++ b/crates/rite-runtime/src/transcript_sink.rs
@@ -9,11 +9,17 @@
 //!
 //! # On-disk format (`transcript.jsonl`)
 //!
-//! Each line is a JSON object with two fields:
+//! Each line is a JSON object with three fields:
 //!
 //! ```jsonc
-//! {"prev_hash": "sha256:…", "fact": { "type": "step_started", … }}
+//! {"prev_hash": "sha256:…", "at": "2026-06-01T20:34:51Z", "fact": { "type": "step_started", … }}
 //! ```
+//!
+//! `at` is the event's wall-clock time, supplied by the executor's clock when
+//! it emits the fact (the sink records it rather than choosing it, so the time
+//! is independent of the storage backend). It is the single uniform timestamp
+//! for every event, and part of the hashed line, so it is tamper-evident like
+//! the rest of the envelope.
 //!
 //! The chain is verified by recomputing each line's SHA-256, accumulating it
 //! as the expected `prev_hash` of the next line, starting from
@@ -29,6 +35,7 @@ use std::fs::{File, OpenOptions};
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -75,14 +82,18 @@ pub const GENESIS_HASH: &str =
 /// relies on this to maintain the invariant that the UI never sees a fact
 /// that has not been durably persisted.
 pub trait TranscriptSink: Send {
-    /// Record a single fact. Must persist before returning, the file-backed
-    /// implementation calls `sync_data` so a power loss after `record`
-    /// returns cannot drop the fact.
+    /// Record a single fact, stamped with the caller-supplied event time `at`.
+    /// Must persist before returning, the file-backed implementation calls
+    /// `sync_data` so a power loss after `record` returns cannot drop the fact.
+    ///
+    /// `at` is supplied by the executor (the clock owner), not read here, so the
+    /// recorded time is independent of the persistence implementation and the
+    /// sink stays a deterministic serializer.
     ///
     /// # Errors
     ///
     /// Returns the underlying I/O error if the sink cannot persist the fact.
-    fn record(&mut self, fact: &StepFact) -> io::Result<()>;
+    fn record(&mut self, at: DateTime<Utc>, fact: &StepFact) -> io::Result<()>;
 
     /// Finalize the transcript and return its fingerprint.
     ///
@@ -140,12 +151,13 @@ impl JsonlFileSink {
 }
 
 impl TranscriptSink for JsonlFileSink {
-    fn record(&mut self, fact: &StepFact) -> io::Result<()> {
+    fn record(&mut self, at: DateTime<Utc>, fact: &StepFact) -> io::Result<()> {
         if self.finalized.is_some() {
             return Err(io::Error::other("transcript already finalized"));
         }
         let line = ChainedFact {
             prev_hash: &self.current_hash,
+            at,
             fact,
         };
         let bytes = serde_json::to_vec(&line).map_err(io::Error::other)?;
@@ -215,12 +227,13 @@ impl InMemorySink {
 }
 
 impl TranscriptSink for InMemorySink {
-    fn record(&mut self, fact: &StepFact) -> io::Result<()> {
+    fn record(&mut self, at: DateTime<Utc>, fact: &StepFact) -> io::Result<()> {
         if self.finalized.is_some() {
             return Err(io::Error::other("transcript already finalized"));
         }
         let line = ChainedFact {
             prev_hash: &self.current_hash,
+            at,
             fact,
         };
         let bytes = serde_json::to_vec(&line).map_err(io::Error::other)?;
@@ -242,13 +255,26 @@ impl TranscriptSink for InMemorySink {
 #[derive(Serialize)]
 struct ChainedFact<'a> {
     prev_hash: &'a str,
+    at: DateTime<Utc>,
     fact: &'a StepFact,
 }
 
 #[derive(Deserialize)]
 struct OwnedChainedFact {
     prev_hash: String,
+    at: DateTime<Utc>,
     fact: StepFact,
+}
+
+/// A recorded fact paired with its envelope timestamp: the uniform event time,
+/// which lives on the chain envelope rather than on individual facts. Returned
+/// by [`read_verified_transcript`] so consumers read event time uniformly.
+#[derive(Debug, Clone)]
+pub struct TimedFact {
+    /// Wall-clock time the fact was recorded.
+    pub at: DateTime<Utc>,
+    /// The recorded fact.
+    pub fact: StepFact,
 }
 
 /// Outcome of verifying a transcript on disk.
@@ -334,8 +360,9 @@ pub fn verify_transcript(jsonl_path: &Path) -> Result<TranscriptVerified, Verify
 /// fingerprint and a flag for whether the run reached a terminal fact.
 #[derive(Debug, Clone)]
 pub struct LoadedTranscript {
-    /// Facts in the order they were recorded.
-    pub facts: Vec<StepFact>,
+    /// Facts in the order they were recorded, each paired with the envelope
+    /// timestamp the sink stamped when it wrote the line.
+    pub facts: Vec<TimedFact>,
     /// Final transcript fingerprint (hash of the last line).
     pub fingerprint: TranscriptFingerprint,
     /// `true` if the last fact is `CeremonyCompleted` or `CeremonyFailed`.
@@ -357,7 +384,7 @@ pub fn read_verified_transcript(jsonl_path: &Path) -> Result<LoadedTranscript, V
 
     let mut expected_prev = GENESIS_HASH.to_string();
     let mut last_hash = expected_prev.clone();
-    let mut facts: Vec<StepFact> = Vec::new();
+    let mut facts: Vec<TimedFact> = Vec::new();
 
     for (idx, line) in reader.lines().enumerate() {
         let line = line?;
@@ -376,7 +403,10 @@ pub fn read_verified_transcript(jsonl_path: &Path) -> Result<LoadedTranscript, V
         }
         last_hash = compute_fingerprint(line.as_bytes());
         expected_prev.clone_from(&last_hash);
-        facts.push(parsed.fact);
+        facts.push(TimedFact {
+            at: parsed.at,
+            fact: parsed.fact,
+        });
     }
 
     if facts.is_empty() {
@@ -384,7 +414,7 @@ pub fn read_verified_transcript(jsonl_path: &Path) -> Result<LoadedTranscript, V
     }
 
     let terminated = matches!(
-        facts.last(),
+        facts.last().map(|t| &t.fact),
         Some(StepFact::CeremonyCompleted { .. } | StepFact::CeremonyFailed { .. }),
     );
 
@@ -423,7 +453,9 @@ pub struct EntropyVerified {
 /// Returns a [`VerifyError`] variant describing the first inconsistency:
 /// [`VerifyError::SeedMissing`], [`VerifyError::UnknownDerivation`],
 /// [`VerifyError::MalformedEntropy`], or [`VerifyError::DrawMismatch`].
-pub fn verify_entropy(facts: &[StepFact]) -> Result<EntropyVerified, VerifyError> {
+pub fn verify_entropy<'a>(
+    facts: impl IntoIterator<Item = &'a StepFact>,
+) -> Result<EntropyVerified, VerifyError> {
     let mut seed: Option<[u8; 32]> = None;
     let mut result = EntropyVerified::default();
 
@@ -464,14 +496,12 @@ pub fn verify_entropy(facts: &[StepFact]) -> Result<EntropyVerified, VerifyError
 
 #[cfg(test)]
 mod tests {
-    use chrono::Utc;
-
     use super::*;
+    use crate::test_support::fixed_test_time as test_at;
 
     fn sample_fact() -> StepFact {
         StepFact::CeremonyStarted {
             name: "Test".to_string(),
-            started_at: Utc::now(),
         }
     }
 
@@ -479,7 +509,7 @@ mod tests {
     fn in_memory_sink_records_and_finalizes() {
         let mut sink = InMemorySink::new();
         assert!(sink.is_empty());
-        sink.record(&sample_fact()).expect("record");
+        sink.record(test_at(), &sample_fact()).expect("record");
         assert_eq!(sink.len(), 1);
         let fp = sink.finalize().expect("finalize");
         assert!(fp.as_str().starts_with("sha256:"));
@@ -488,9 +518,11 @@ mod tests {
     #[test]
     fn in_memory_sink_rejects_record_after_finalize() {
         let mut sink = InMemorySink::new();
-        sink.record(&sample_fact()).expect("record");
+        sink.record(test_at(), &sample_fact()).expect("record");
         sink.finalize().expect("finalize");
-        let err = sink.record(&sample_fact()).expect_err("should fail");
+        let err = sink
+            .record(test_at(), &sample_fact())
+            .expect_err("should fail");
         assert!(err.to_string().contains("already finalized"));
     }
 
@@ -498,19 +530,33 @@ mod tests {
     fn in_memory_sink_chain_advances() {
         let mut sink = InMemorySink::new();
         let initial = sink.current_hash.clone();
-        sink.record(&sample_fact()).expect("record");
+        sink.record(test_at(), &sample_fact()).expect("record");
         assert_ne!(sink.current_hash, initial);
         let after_first = sink.current_hash.clone();
-        sink.record(&sample_fact()).expect("record");
+        sink.record(test_at(), &sample_fact()).expect("record");
         assert_ne!(sink.current_hash, after_first);
+    }
+
+    #[test]
+    fn record_persists_the_supplied_time_and_reader_recovers_it() {
+        // The sink records the `at` it is given (it does not read a clock), and
+        // the reader recovers exactly that instant from the envelope.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut sink = JsonlFileSink::create(tmp.path()).expect("create");
+        let at = test_at();
+        sink.record(at, &sample_fact()).expect("record");
+        sink.finalize().expect("finalize");
+
+        let loaded = read_verified_transcript(sink.jsonl_path()).expect("read");
+        assert_eq!(loaded.facts.first().expect("one fact").at, at);
     }
 
     #[test]
     fn jsonl_file_sink_writes_and_chains() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let mut sink = JsonlFileSink::create(tmp.path()).expect("create");
-        sink.record(&sample_fact()).expect("record");
-        sink.record(&sample_fact()).expect("record");
+        sink.record(test_at(), &sample_fact()).expect("record");
+        sink.record(test_at(), &sample_fact()).expect("record");
         let fp = sink.finalize().expect("finalize");
 
         let jsonl = std::fs::read_to_string(sink.jsonl_path()).expect("read jsonl");
@@ -546,9 +592,9 @@ mod tests {
     fn verify_round_trip_succeeds_on_well_formed_transcript() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let mut sink = JsonlFileSink::create(tmp.path()).expect("create");
-        sink.record(&sample_fact()).expect("record");
-        sink.record(&sample_fact()).expect("record");
-        sink.record(&sample_fact()).expect("record");
+        sink.record(test_at(), &sample_fact()).expect("record");
+        sink.record(test_at(), &sample_fact()).expect("record");
+        sink.record(test_at(), &sample_fact()).expect("record");
         let written = sink.finalize().expect("finalize");
 
         let verified = verify_transcript(sink.jsonl_path()).expect("verify");
@@ -562,8 +608,8 @@ mod tests {
     fn verify_detects_chain_break() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let mut sink = JsonlFileSink::create(tmp.path()).expect("create");
-        sink.record(&sample_fact()).expect("record");
-        sink.record(&sample_fact()).expect("record");
+        sink.record(test_at(), &sample_fact()).expect("record");
+        sink.record(test_at(), &sample_fact()).expect("record");
         let _ = sink.finalize().expect("finalize");
 
         let path = sink.jsonl_path().to_path_buf();
@@ -609,11 +655,11 @@ mod tests {
     fn verify_entropy_re_derives_a_clean_draw() {
         let m = b"machine entropy bytes";
         let seed = crate::entropy::initial_seed(m);
-        let facts = vec![
+        let facts = [
             seeded_fact(m),
             drawn_fact(&seed, "issue", "0/issue/cert-serial", 9),
         ];
-        let v = verify_entropy(&facts).expect("verify");
+        let v = verify_entropy(facts.iter()).expect("verify");
         assert_eq!(v.values_verified, 1);
         assert_eq!(v.contributions, 0);
         assert_eq!(v.derivation.as_deref(), Some("rite-kdf/v1"));
@@ -624,7 +670,7 @@ mod tests {
         let m = b"machine entropy bytes";
         let seed0 = crate::entropy::initial_seed(m);
         let seed1 = crate::entropy::fold_seed(&seed0, b"3 1 6 4 2 5");
-        let facts = vec![
+        let facts = [
             seeded_fact(m),
             StepFact::EntropyContributed {
                 step: StepId::new("roll"),
@@ -634,7 +680,7 @@ mod tests {
             // Drawn after the fold, so it must derive from the epoch-1 seed.
             drawn_fact(&seed1, "issue", "1/issue/cert-serial", 9),
         ];
-        let v = verify_entropy(&facts).expect("verify");
+        let v = verify_entropy(facts.iter()).expect("verify");
         assert_eq!(v.contributions, 1);
         assert_eq!(v.values_verified, 1);
     }
@@ -647,27 +693,27 @@ mod tests {
         if let StepFact::EntropyDrawn { value, .. } = &mut drawn {
             *value = "deadbeefdeadbeefdead".to_string();
         }
-        let facts = vec![seeded_fact(m), drawn];
-        let err = verify_entropy(&facts).expect_err("tamper");
+        let facts = [seeded_fact(m), drawn];
+        let err = verify_entropy(facts.iter()).expect_err("tamper");
         assert!(matches!(err, VerifyError::DrawMismatch { .. }));
     }
 
     #[test]
     fn verify_entropy_rejects_unknown_derivation() {
-        let facts = vec![StepFact::EntropySeeded {
+        let facts = [StepFact::EntropySeeded {
             m: "00".to_string(),
             source: "os".to_string(),
             derivation: "rite-kdf/v99".to_string(),
         }];
-        let err = verify_entropy(&facts).expect_err("unknown scheme");
+        let err = verify_entropy(facts.iter()).expect_err("unknown scheme");
         assert!(matches!(err, VerifyError::UnknownDerivation(_)));
     }
 
     #[test]
     fn verify_entropy_rejects_draw_before_seed() {
         let seed = crate::entropy::initial_seed(b"x");
-        let facts = vec![drawn_fact(&seed, "issue", "0/issue/cert-serial", 9)];
-        let err = verify_entropy(&facts).expect_err("unseeded");
+        let facts = [drawn_fact(&seed, "issue", "0/issue/cert-serial", 9)];
+        let err = verify_entropy(facts.iter()).expect_err("unseeded");
         assert!(matches!(err, VerifyError::SeedMissing));
     }
 }

--- a/crates/rite-stdlib/src/attestation/attest.rs
+++ b/crates/rite-stdlib/src/attestation/attest.rs
@@ -1,6 +1,5 @@
 //! `attest` action, record a formal attestation by a named role.
 
-use chrono::Utc;
 use rite_model::{ActionType, Prompt, RoleId, StepFact};
 use rite_runtime::{
     Action, ActionCategory, ActionError, ActionMetadata, HandlerContext, Icon, Reporter, StepInfo,
@@ -75,7 +74,6 @@ impl Action for AttestAction {
             step: step.id.clone(),
             role,
             statement: statement.clone(),
-            at: Utc::now(),
         })?;
 
         Ok(StepResult::completed(format!(

--- a/crates/rite-tui/src/model.rs
+++ b/crates/rite-tui/src/model.rs
@@ -127,8 +127,15 @@ impl Model {
     /// and the model's wall-clock snapshot so the Ceremony tab can render
     /// a per-row step and timestamp column.
     pub(crate) fn push_entry(&mut self, icon: Icon, text: String) {
+        self.push_entry_at(icon, text, self.now);
+    }
+
+    /// Push a log entry stamped with an explicit event time. Used for facts so
+    /// the Ceremony tab's timestamp column shows when the event actually
+    /// happened, not when the drip queue drained it. `push_entry` (for signals,
+    /// which have no event time) delegates here with the live `now`.
+    pub(crate) fn push_entry_at(&mut self, icon: Icon, text: String, at: DateTime<Local>) {
         let step = self.current_step.as_ref().map(|s| s.label.clone());
-        let at = self.now;
         self.push_log(LogLine::Entry {
             icon,
             text,

--- a/crates/rite-tui/src/update.rs
+++ b/crates/rite-tui/src/update.rs
@@ -5,6 +5,7 @@
 //! outside world is returned as a [`Cmd`] for the runtime loop to
 //! interpret.
 
+use chrono::{DateTime, Utc};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use rite_model::{Prompt, StepFact};
@@ -358,7 +359,7 @@ fn send_response(model: &mut Model, response: Response) -> Vec<Cmd> {
 
 fn handle_exec_event(model: &mut Model, event: ExecEvent) -> Vec<Cmd> {
     match event {
-        ExecEvent::Fact(fact) => handle_fact(model, &fact),
+        ExecEvent::Fact { at, fact } => handle_fact(model, at, &fact),
         ExecEvent::Signal(signal) => handle_signal(model, &signal),
         ExecEvent::AwaitPrompt {
             prompt_id,
@@ -395,7 +396,12 @@ fn install_prompt(
     });
 }
 
-fn handle_fact(model: &mut Model, fact: &StepFact) -> Vec<Cmd> {
+fn handle_fact(model: &mut Model, at: DateTime<Utc>, fact: &StepFact) -> Vec<Cmd> {
+    // Event time from the transcript envelope, rendered in the operator's local
+    // zone. Carried on the event so it survives the drip queue: the log column
+    // and deviation list show when the event happened, not when it drained.
+    let at_local = at.with_timezone(&chrono::Local);
+
     // Model-specific side-effects first (header, dividers, screen
     // transitions, deviation list). The log feed is fed afterwards from
     // the shared `fact_summary`, so the live log mirrors the console
@@ -443,11 +449,11 @@ fn handle_fact(model: &mut Model, fact: &StepFact) -> Vec<Cmd> {
         StepFact::StepCompleted { .. } => {
             model.pending_prompt = None;
         }
-        StepFact::DeviationRecorded { step, text, at } => {
+        StepFact::DeviationRecorded { step, text } => {
             model.deviations.push(DeviationView {
                 step: step.clone(),
                 text: text.clone(),
-                at: at.with_timezone(&chrono::Local),
+                at: at_local,
             });
         }
         StepFact::CeremonyCompleted { .. } => {
@@ -471,7 +477,7 @@ fn handle_fact(model: &mut Model, fact: &StepFact) -> Vec<Cmd> {
         StepFact::StepStarted { .. } | StepFact::ActStarted { .. }
     ) && let Some((icon, text)) = fact_summary(fact)
     {
-        model.push_entry(icon, text);
+        model.push_entry_at(icon, text, at_local);
     }
 
     Vec::new()
@@ -505,8 +511,8 @@ fn handle_signal(model: &mut Model, signal: &UiSignal) -> Vec<Cmd> {
 
 #[cfg(test)]
 mod tests {
-    use chrono::Utc;
     use rite_model::StepId;
+    use rite_runtime::test_support::fact_event;
 
     use super::*;
 
@@ -649,12 +655,11 @@ mod tests {
         let mut model = Model::new();
         let _ = apply_exec(
             &mut model,
-            ExecEvent::Fact(StepFact::StepStarted {
+            fact_event(StepFact::StepStarted {
                 id: StepId::new("s1"),
                 label: "2.1".to_string(),
                 role: rite_model::RoleId::new("crypto_officer"),
                 role_name: "Crypto Officer".to_string(),
-                started_at: Utc::now(),
             }),
         );
         assert!(matches!(model.screen, Screen::Step { .. }));
@@ -712,12 +717,11 @@ mod tests {
         let mut model = Model::new();
         let _ = apply_exec(
             &mut model,
-            ExecEvent::Fact(StepFact::StepStarted {
+            fact_event(StepFact::StepStarted {
                 id: StepId::new("s1"),
                 label: "1".to_string(),
                 role: rite_model::RoleId::new("op"),
                 role_name: "Operator".to_string(),
-                started_at: Utc::now(),
             }),
         );
         assert!(matches!(
@@ -734,12 +738,11 @@ mod tests {
         // First step transition auto-switches to Ceremony.
         let _ = apply_exec(
             &mut model,
-            ExecEvent::Fact(StepFact::StepStarted {
+            fact_event(StepFact::StepStarted {
                 id: StepId::new("s1"),
                 label: "1".to_string(),
                 role: rite_model::RoleId::new("op"),
                 role_name: "Operator".to_string(),
-                started_at: Utc::now(),
             }),
         );
         // Operator switches back to Overview to re-read the description.
@@ -755,12 +758,11 @@ mod tests {
         // Second step must not yank the operator off Overview.
         let _ = apply_exec(
             &mut model,
-            ExecEvent::Fact(StepFact::StepStarted {
+            fact_event(StepFact::StepStarted {
                 id: StepId::new("s2"),
                 label: "2".to_string(),
                 role: rite_model::RoleId::new("op"),
                 role_name: "Operator".to_string(),
-                started_at: Utc::now(),
             }),
         );
         assert!(matches!(
@@ -776,9 +778,8 @@ mod tests {
         let mut model = Model::new();
         let _ = apply_exec(
             &mut model,
-            ExecEvent::Fact(StepFact::CeremonyStarted {
+            fact_event(StepFact::CeremonyStarted {
                 name: "Root CA".to_string(),
-                started_at: Utc::now(),
             }),
         );
         assert_eq!(model.ceremony_name.as_deref(), Some("Root CA"));
@@ -829,9 +830,8 @@ mod tests {
             label: "Step One".to_string(),
             role: rite_model::RoleId::new("op"),
             role_name: "Operator".to_string(),
-            started_at: Utc::now(),
         };
-        let _ = apply_exec(&mut model, ExecEvent::Fact(fact));
+        let _ = apply_exec(&mut model, fact_event(fact));
         let s = model.current_step.expect("current step");
         assert_eq!(s.id, StepId::new("s1"));
         assert_eq!(s.label, "Step One");
@@ -900,10 +900,8 @@ mod tests {
     #[test]
     fn ceremony_completed_then_finalized_populates_fingerprint() {
         let mut model = Model::new();
-        let fact = StepFact::CeremonyCompleted {
-            completed_at: Utc::now(),
-        };
-        let _ = apply_exec(&mut model, ExecEvent::Fact(fact));
+        let fact = StepFact::CeremonyCompleted {};
+        let _ = apply_exec(&mut model, fact_event(fact));
         assert!(matches!(
             model.screen,
             Screen::Completed {
@@ -937,9 +935,7 @@ mod tests {
         // drip buffer when Quit arrives.
         let _ = update(
             &mut model,
-            Msg::Exec(ExecEvent::Fact(StepFact::CeremonyCompleted {
-                completed_at: Utc::now(),
-            })),
+            Msg::Exec(fact_event(StepFact::CeremonyCompleted {})),
         );
         let _ = update(
             &mut model,

--- a/crates/rite/src/console.rs
+++ b/crates/rite/src/console.rs
@@ -66,7 +66,7 @@ pub fn run(cmd_tx: &Sender<UiCommand>, event_rx: &Receiver<ExecEvent>) -> io::Re
 
     while let Ok(event) = event_rx.recv() {
         match event {
-            ExecEvent::Fact(fact) => render_fact(&mut stdout, &fact)?,
+            ExecEvent::Fact { fact, .. } => render_fact(&mut stdout, &fact)?,
             ExecEvent::Signal(signal) => render_signal(&mut stdout, &signal)?,
             ExecEvent::Finalized { fingerprint } => {
                 writeln!(
@@ -227,12 +227,12 @@ fn read_line<R: BufRead>(stdin: &mut R) -> io::Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use chrono::Utc;
     use crossbeam_channel::unbounded;
     use rite_model::{ResponseRecord, StepId};
 
     use super::*;
     use rite_runtime::PromptId;
+    use rite_runtime::test_support::fact_event;
 
     #[test]
     fn renders_each_fact_kind_without_panicking() {
@@ -240,14 +240,12 @@ mod tests {
         let facts = vec![
             StepFact::CeremonyStarted {
                 name: "T".to_string(),
-                started_at: Utc::now(),
             },
             StepFact::StepStarted {
                 id: StepId::new("a"),
                 label: "Step A".to_string(),
                 role: rite_model::RoleId::new("op"),
                 role_name: "Operator".to_string(),
-                started_at: Utc::now(),
             },
             StepFact::PromptAnswered {
                 step: Some(StepId::new("a")),
@@ -256,18 +254,14 @@ mod tests {
                     default: None,
                 },
                 response: ResponseRecord::Bool { value: true },
-                at: Utc::now(),
             },
             StepFact::StepCompleted {
                 id: StepId::new("a"),
                 outcome: rite_model::StepOutcome::Completed {
                     message: "done".to_string(),
                 },
-                completed_at: Utc::now(),
             },
-            StepFact::CeremonyCompleted {
-                completed_at: Utc::now(),
-            },
+            StepFact::CeremonyCompleted {},
         ];
         for fact in &facts {
             render_fact(&mut buf, fact).expect("render");
@@ -325,9 +319,8 @@ mod tests {
         // Send only events the helper sees:
         let prompt_id = PromptId::new(7);
         event_tx
-            .send(ExecEvent::Fact(StepFact::CeremonyStarted {
+            .send(fact_event(StepFact::CeremonyStarted {
                 name: "T".to_string(),
-                started_at: Utc::now(),
             }))
             .expect("send fact");
         event_tx

--- a/crates/rite/src/headless.rs
+++ b/crates/rite/src/headless.rs
@@ -40,7 +40,7 @@ pub fn run(cmd_tx: &Sender<UiCommand>, event_rx: &Receiver<ExecEvent>) -> io::Re
 
     while let Ok(event) = event_rx.recv() {
         match event {
-            ExecEvent::Fact(fact) => render_fact(&mut stderr, &fact)?,
+            ExecEvent::Fact { fact, .. } => render_fact(&mut stderr, &fact)?,
             ExecEvent::Signal(signal) => render_signal(&mut stderr, &signal)?,
             ExecEvent::Finalized { fingerprint } => {
                 writeln!(stderr, "[fingerprint] {fingerprint}")?;
@@ -113,12 +113,12 @@ fn render_signal<W: Write>(out: &mut W, signal: &UiSignal) -> io::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use chrono::Utc;
     use crossbeam_channel::unbounded;
     use rite_model::StepId;
 
     use super::*;
     use rite_runtime::PromptId;
+    use rite_runtime::test_support::fact_event;
 
     #[test]
     fn confirm_default_yes() {
@@ -187,9 +187,8 @@ mod tests {
 
         // Simulate a runtime: send a couple of facts and a Continue prompt.
         event_tx
-            .send(ExecEvent::Fact(StepFact::CeremonyStarted {
+            .send(fact_event(StepFact::CeremonyStarted {
                 name: "T".to_string(),
-                started_at: Utc::now(),
             }))
             .expect("send fact");
         event_tx

--- a/crates/rite/src/report.rs
+++ b/crates/rite/src/report.rs
@@ -37,7 +37,10 @@ pub fn run(args: &Args) {
         }
     };
 
-    let data = build_report_data(&loaded.facts, loaded.fingerprint.as_str());
+    let data = build_report_data(
+        loaded.facts.iter().map(|t| (t.at, &t.fact)),
+        loaded.fingerprint.as_str(),
+    );
     let branding = build_branding_or_exit(&args.branding);
     let html =
         rite_render::render_report(&data, &branding, args.theme.into()).unwrap_or_else(|e| {

--- a/crates/rite/src/verify.rs
+++ b/crates/rite/src/verify.rs
@@ -24,7 +24,7 @@ pub fn run(args: Args) {
             // The hash chain is intact. Now re-derive the entropy source so
             // every recorded random value is proven to come from the recorded
             // seed, not cherry-picked.
-            let entropy = match verify_entropy(&loaded.facts) {
+            let entropy = match verify_entropy(loaded.facts.iter().map(|t| &t.fact)) {
                 Ok(entropy) => entropy,
                 Err(err) => {
                     eprintln!("Verification failed: {err}");

--- a/docs/development/runtime-and-frontend.md
+++ b/docs/development/runtime-and-frontend.md
@@ -137,8 +137,15 @@ and `fsync`s before returning, so a fact the executor has moved past
 cannot be lost to a subsequent crash or power loss. Each line:
 
 ```jsonc
-{"prev_hash": "sha256:…", "fact": { "type": "step_started", … }}
+{"prev_hash": "sha256:…", "at": "2026-06-01T20:34:51Z", "fact": { "type": "step_started", … }}
 ```
+
+`at` is the wall-clock time the sink stamped when it wrote the line, the
+single uniform timestamp for every event. Individual facts carry no
+timestamp of their own; a timestamp that is *data* rather than record time
+(a future `clock_check` observed time, an RFC 3161 token) would be a field
+on the fact. Because `at` is part of the line, it is covered by the hash
+chain like the rest of the envelope.
 
 Each line's SHA-256 is the next line's `prev_hash`. The hash of the
 final line *is* the transcript fingerprint; the JSONL is self-identifying


### PR DESCRIPTION
Some StepFact variants carried their own event time while the rest carried none, each stamped at fact-construction time. Replace them with one `at` field on the chain envelope, recorded on every line, so every event is timed uniformly and the timestamp is covered by the hash chain.

Closes #81