### PR TITLE
fix(security): confine ceremony-derived paths to their directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,6 +1734,7 @@ dependencies = [
  "rite-model",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
 ]
 

--- a/crates/rite-model/src/lib.rs
+++ b/crates/rite-model/src/lib.rs
@@ -9,6 +9,7 @@
 //! - [`ir`]: IR types: [`Ceremony`], [`Step`], [`Role`], etc. and typed ID newtypes
 //! - [`expression`]: Expression parsing for `${artifact.name | sha256 | hex}` syntax
 //! - [`transcript`]: Persisted transcript schema (`StepFact` + friends)
+//! - [`safe_path`]: Confine untrusted, ceremony-derived names/paths to a directory
 //! - `types` (private): Shared semantic enums: [`ActionType`], [`DutyType`], etc.
 //!
 //! # `BackendConfig`
@@ -20,12 +21,15 @@
 pub mod expression;
 pub mod ir;
 mod material;
+pub mod safe_path;
 pub mod transcript;
 mod types;
 
 pub use rite_sdk::BackendConfig;
 
 pub use material::MaterialSource;
+
+pub use safe_path::{PathSafetyError, confine, is_safe_component, safe_join, validate_component};
 
 pub use types::{
     ActionType, DutyType, Metadata, OutputType, ParameterType, derive_role_name, derive_step_name,

--- a/crates/rite-model/src/safe_path.rs
+++ b/crates/rite-model/src/safe_path.rs
@@ -1,0 +1,463 @@
+//! Path-safety helpers for confining ceremony-derived names and paths.
+//!
+//! Ceremony files are authored by third parties and may be downloaded and run
+//! by an operator who never inspected them. Any string from a ceremony that
+//! ends up on the filesystem — an artifact id used as an output filename, a
+//! material's `path:` value — is therefore untrusted and must not be allowed to
+//! escape the directory it is meant to live in.
+//!
+//! Two primitives cover the cases that occur in practice:
+//!
+//! - [`validate_component`] / [`safe_join`] for a value that must be a single
+//!   path component (a bare file or directory name). This is the right tool for
+//!   identifiers that become filenames. Because these names are *created* by
+//!   the runtime and a ceremony is portable across operating systems, the rules
+//!   are the intersection of what every platform accepts (see
+//!   [`validate_component`] for the full list).
+//! - [`confine`] for a value that may legitimately be a multi-segment relative
+//!   path but must stay within a known root (e.g. `keys/root.pem` under the
+//!   ceremony directory). This is used for *reading* files that already exist
+//!   on the host, so it only enforces containment, not name portability.
+//!
+//! Both are purely lexical: they never touch the filesystem, so they are safe to
+//! call on paths that do not exist yet and cannot be confused by the current
+//! working directory. Lexical checks do **not** defend against symlinks placed
+//! at the destination — call sites that create files should additionally open
+//! with `create_new` (no-follow, no-clobber) so a pre-planted symlink cannot
+//! redirect the write.
+
+use std::fmt;
+use std::path::{Component, Path, PathBuf};
+
+/// Characters rejected in created filenames beyond the separators.
+///
+/// This is the set Windows disallows in file and directory names, per
+/// Microsoft's "Naming Files, Paths, and Namespaces" documentation; it matches
+/// `DISALLOWED_FILENAME_CHARS` in the `typed-path` crate (v0.12, MIT OR
+/// Apache-2.0) minus the separators and NUL, which are rejected separately.
+/// `:` is the security-relevant one — on NTFS, `name:stream` writes to an
+/// alternate data stream and `C:name` is drive-relative — the rest fail or
+/// misbehave in shells and UI. Rejected on every platform because the name may
+/// be created on one OS and the run directory copied to another.
+const ILLEGAL_FILENAME_CHARS: &[char] = &[':', '?', '*', '"', '>', '<', '|'];
+
+/// Names Windows reserves for devices, matched case-insensitively against the
+/// portion of the name before the first `.` (`NUL.txt` is reserved too).
+///
+/// List adapted from `RESERVED_DEVICE_NAMES` in the `typed-path` crate (v0.12,
+/// MIT OR Apache-2.0), which extends Microsoft's documented set with `COM0` /
+/// `LPT0`. The match-with-extension semantics follow the `sanitize-filename`
+/// crate (v0.6, MIT).
+const WINDOWS_RESERVED_NAMES: &[&str] = &[
+    "CON", "PRN", "AUX", "NUL", "COM0", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7",
+    "COM8", "COM9", "LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+];
+
+/// Maximum filename length in bytes (`NAME_MAX` on Linux, the common floor
+/// across filesystems).
+const MAX_COMPONENT_BYTES: usize = 255;
+
+/// Why a ceremony-supplied name or path was rejected as unsafe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PathSafetyError {
+    /// The value was empty.
+    Empty,
+    /// The value was absolute, or carried a root / drive prefix, where a
+    /// relative path was required.
+    NotRelative,
+    /// The value escaped its intended root via one or more `..` components.
+    Traversal,
+    /// A value that had to be a single path component contained a directory
+    /// separator (`/` or `\`).
+    Separator,
+    /// The name contained a character that is not portable in filenames
+    /// (one of `: ? * " > < |`, or a control character).
+    IllegalCharacter(char),
+    /// The name is reserved by Windows for a device (`CON`, `NUL`, `COM1`, …),
+    /// with or without an extension.
+    ReservedName,
+    /// The name ends with a `.` or a space, which Windows strips on creation —
+    /// `key.` and `key` would silently alias the same file.
+    TrailingDotOrSpace,
+    /// The name exceeds 255 bytes, the common filesystem limit for a single
+    /// path component.
+    TooLong,
+}
+
+impl fmt::Display for PathSafetyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PathSafetyError::Empty => write!(f, "path is empty"),
+            PathSafetyError::NotRelative => {
+                write!(f, "path must be relative (no leading '/' or drive prefix)")
+            }
+            PathSafetyError::Traversal => {
+                write!(f, "path escapes its directory via '..'")
+            }
+            PathSafetyError::Separator => {
+                write!(f, "name must not contain a path separator ('/' or '\\')")
+            }
+            PathSafetyError::IllegalCharacter(c) => {
+                write!(f, "name contains {c:?}, which is not portable in filenames")
+            }
+            PathSafetyError::ReservedName => {
+                write!(f, "name is reserved for a device on Windows")
+            }
+            PathSafetyError::TrailingDotOrSpace => {
+                write!(f, "name must not end with '.' or a space")
+            }
+            PathSafetyError::TooLong => {
+                write!(f, "name exceeds {MAX_COMPONENT_BYTES} bytes")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PathSafetyError {}
+
+/// Validate that `name` is a safe, portable single path component: a non-empty
+/// plain file or directory name that every supported platform accepts and that
+/// cannot leave its directory.
+///
+/// Rejected, in order of checking:
+///
+/// - the empty string
+/// - separators `/` and `\`
+/// - `.` and `..`
+/// - characters Windows disallows in names (`: ? * " > < |`) and control
+///   characters (C0, C1, DEL — these also enable terminal-escape spoofing when
+///   a path is echoed)
+/// - Windows reserved device names (`CON`, `NUL`, `COM1`, …), with or without
+///   an extension
+/// - trailing `.` or space (Windows strips them, silently aliasing names)
+/// - names longer than 255 bytes (`NAME_MAX`)
+/// - anything `Path::components` does not parse as exactly one normal
+///   component on the host platform (e.g. a bare drive prefix)
+///
+/// # Errors
+/// Returns a [`PathSafetyError`] describing the first rule the name violates.
+pub fn validate_component(name: &str) -> Result<(), PathSafetyError> {
+    if name.is_empty() {
+        return Err(PathSafetyError::Empty);
+    }
+    if name.contains('/') || name.contains('\\') {
+        return Err(PathSafetyError::Separator);
+    }
+    if name == "." || name == ".." {
+        return Err(PathSafetyError::Traversal);
+    }
+    // `is_control` covers C0 (0x00-0x1F), DEL, and C1 (0x80-0x9F).
+    if let Some(c) = name
+        .chars()
+        .find(|c| c.is_control() || ILLEGAL_FILENAME_CHARS.contains(c))
+    {
+        return Err(PathSafetyError::IllegalCharacter(c));
+    }
+    let stem = name.split('.').next().unwrap_or(name);
+    if WINDOWS_RESERVED_NAMES
+        .iter()
+        .any(|r| r.eq_ignore_ascii_case(stem))
+    {
+        return Err(PathSafetyError::ReservedName);
+    }
+    if name.ends_with(['.', ' ']) {
+        return Err(PathSafetyError::TrailingDotOrSpace);
+    }
+    if name.len() > MAX_COMPONENT_BYTES {
+        return Err(PathSafetyError::TooLong);
+    }
+    // Anything that does not resolve to exactly one "normal" component (e.g. a
+    // bare drive prefix like `C:` on Windows) is not a plain name.
+    let mut components = Path::new(name).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(_)), None) => Ok(()),
+        _ => Err(PathSafetyError::NotRelative),
+    }
+}
+
+/// Returns `true` if `name` is a safe single path component.
+///
+/// Convenience wrapper over [`validate_component`] for boolean checks.
+#[must_use]
+pub fn is_safe_component(name: &str) -> bool {
+    validate_component(name).is_ok()
+}
+
+/// Join a single untrusted `name` onto `base`, guaranteeing the result is a
+/// direct child of `base`.
+///
+/// # Errors
+/// Returns a [`PathSafetyError`] if `name` is not a safe single component (see
+/// [`validate_component`]).
+pub fn safe_join(base: &Path, name: &str) -> Result<PathBuf, PathSafetyError> {
+    validate_component(name)?;
+    Ok(base.join(name))
+}
+
+/// Resolve an untrusted relative `candidate` against `root`, guaranteeing the
+/// result stays within `root`.
+///
+/// Interior `.` and `..` components are normalized lexically; `candidate` is
+/// rejected if it is empty, absolute, or if its `..` components would climb
+/// above `root`. The returned path is `root` with the normalized, confined
+/// remainder appended.
+///
+/// Unlike [`validate_component`], this does not enforce name portability —
+/// it is meant for paths to existing files on the host, where the host's own
+/// rules already applied when the file was created.
+///
+/// # Errors
+/// Returns [`PathSafetyError::Empty`] if `candidate` is empty,
+/// [`PathSafetyError::NotRelative`] if it is absolute or carries a
+/// root/prefix, or [`PathSafetyError::Traversal`] if it escapes `root`.
+pub fn confine(root: &Path, candidate: &Path) -> Result<PathBuf, PathSafetyError> {
+    if candidate.as_os_str().is_empty() {
+        return Err(PathSafetyError::Empty);
+    }
+    if candidate.is_absolute() {
+        return Err(PathSafetyError::NotRelative);
+    }
+
+    let mut relative = PathBuf::new();
+    let mut depth: usize = 0;
+    for component in candidate.components() {
+        match component {
+            Component::Normal(segment) => {
+                relative.push(segment);
+                depth = depth.saturating_add(1);
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if depth == 0 {
+                    return Err(PathSafetyError::Traversal);
+                }
+                relative.pop();
+                depth = depth.saturating_sub(1);
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(PathSafetyError::NotRelative);
+            }
+        }
+    }
+
+    Ok(root.join(relative))
+}
+
+#[cfg(test)]
+mod tests {
+    // Several accept/reject vectors below are adapted from the test corpus of
+    // the `sanitize-filename` crate (v0.6, MIT), which in turn derives from
+    // node-sanitize-filename (ISC). The `confine` normalization cases are
+    // adapted from the test suite of the `path-clean` crate (v1.0, MIT OR
+    // Apache-2.0).
+    use super::*;
+
+    #[test]
+    fn accepts_plain_names() {
+        assert!(is_safe_component("wrapped_key"));
+        assert!(is_safe_component("root_ca_cert.pem"));
+        assert!(is_safe_component("share-1"));
+        // Unusual but legal everywhere.
+        assert!(is_safe_component("résumé"));
+        assert!(is_safe_component("semi;colon.js"));
+        assert!(is_safe_component("singlequote'.js"));
+        assert!(is_safe_component("plus+.js"));
+        assert!(is_safe_component(" space at front"));
+        assert!(is_safe_component(".period"));
+    }
+
+    #[test]
+    fn rejects_separators_and_traversal_in_components() {
+        assert_eq!(
+            validate_component("../etc/passwd"),
+            Err(PathSafetyError::Separator)
+        );
+        assert_eq!(validate_component("a/b"), Err(PathSafetyError::Separator));
+        assert_eq!(validate_component("a\\b"), Err(PathSafetyError::Separator));
+        assert_eq!(validate_component(".."), Err(PathSafetyError::Traversal));
+        assert_eq!(validate_component("."), Err(PathSafetyError::Traversal));
+        assert_eq!(validate_component(""), Err(PathSafetyError::Empty));
+    }
+
+    #[test]
+    fn rejects_absolute_component() {
+        // A leading separator makes this contain a separator first.
+        assert_eq!(validate_component("/abs"), Err(PathSafetyError::Separator));
+    }
+
+    #[test]
+    fn rejects_windows_illegal_characters() {
+        // `:` is the dangerous one: NTFS alternate data stream / drive-relative.
+        assert_eq!(
+            validate_component("key.pem:hidden"),
+            Err(PathSafetyError::IllegalCharacter(':'))
+        );
+        assert_eq!(
+            validate_component("C:"),
+            Err(PathSafetyError::IllegalCharacter(':'))
+        );
+        for name in [
+            "col:on.js",
+            "star*.js",
+            "question?.js",
+            "quote\".js",
+            "brack<e>ts.js",
+            "p|pes.js",
+        ] {
+            assert!(
+                matches!(
+                    validate_component(name),
+                    Err(PathSafetyError::IllegalCharacter(_))
+                ),
+                "{name:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_control_characters() {
+        assert_eq!(
+            validate_component("hello\u{0000}world"),
+            Err(PathSafetyError::IllegalCharacter('\u{0000}'))
+        );
+        assert_eq!(
+            validate_component("hello\nworld"),
+            Err(PathSafetyError::IllegalCharacter('\n'))
+        );
+        // ANSI escape, the terminal-spoofing vector.
+        assert_eq!(
+            validate_component("key\u{001b}[2K.pem"),
+            Err(PathSafetyError::IllegalCharacter('\u{001b}'))
+        );
+        // C1 range.
+        assert_eq!(
+            validate_component("a\u{0085}b"),
+            Err(PathSafetyError::IllegalCharacter('\u{0085}'))
+        );
+    }
+
+    #[test]
+    fn rejects_windows_reserved_device_names() {
+        for name in ["CON", "con", "NUL", "nul.txt", "LPT9.asdf", "COM1.tar.gz"] {
+            assert_eq!(
+                validate_component(name),
+                Err(PathSafetyError::ReservedName),
+                "{name:?} should be rejected"
+            );
+        }
+        // Longer names and different stems are fine.
+        assert!(is_safe_component("CONSOLE"));
+        assert!(is_safe_component("null.txt"));
+        assert!(is_safe_component("com.example"));
+        assert!(is_safe_component("communication"));
+    }
+
+    #[test]
+    fn rejects_trailing_dot_or_space() {
+        assert_eq!(
+            validate_component("period."),
+            Err(PathSafetyError::TrailingDotOrSpace)
+        );
+        assert_eq!(
+            validate_component("space at end "),
+            Err(PathSafetyError::TrailingDotOrSpace)
+        );
+        assert_eq!(
+            validate_component("foobar..."),
+            Err(PathSafetyError::TrailingDotOrSpace)
+        );
+    }
+
+    #[test]
+    fn rejects_overlong_names() {
+        let long = "a".repeat(300);
+        assert_eq!(validate_component(&long), Err(PathSafetyError::TooLong));
+        let max = "a".repeat(255);
+        assert!(is_safe_component(&max));
+    }
+
+    #[test]
+    fn safe_join_confines_to_base() {
+        let base = Path::new("/runs/c/artifacts");
+        assert_eq!(
+            safe_join(base, "key.pem").unwrap(),
+            PathBuf::from("/runs/c/artifacts/key.pem")
+        );
+        assert!(safe_join(base, "../../etc/passwd").is_err());
+        assert!(safe_join(base, "/etc/passwd").is_err());
+    }
+
+    #[test]
+    fn confine_allows_subpaths() {
+        let root = Path::new("/ceremony");
+        assert_eq!(
+            confine(root, Path::new("keys/root.pem")).unwrap(),
+            PathBuf::from("/ceremony/keys/root.pem")
+        );
+        // Interior `.`/`..` that stays within root is normalized, not rejected.
+        assert_eq!(
+            confine(root, Path::new("keys/../keys/root.pem")).unwrap(),
+            PathBuf::from("/ceremony/keys/root.pem")
+        );
+        assert_eq!(
+            confine(root, Path::new("./root.pem")).unwrap(),
+            PathBuf::from("/ceremony/root.pem")
+        );
+    }
+
+    #[test]
+    fn confine_normalizes_like_path_clean() {
+        let root = Path::new("/ceremony");
+        // Repeated separators collapse.
+        assert_eq!(
+            confine(root, Path::new("path//to///thing")).unwrap(),
+            PathBuf::from("/ceremony/path/to/thing")
+        );
+        // `.` segments vanish wherever they appear.
+        assert_eq!(
+            confine(root, Path::new("./test/./path")).unwrap(),
+            PathBuf::from("/ceremony/test/path")
+        );
+        assert_eq!(
+            confine(root, Path::new("test/path/.")).unwrap(),
+            PathBuf::from("/ceremony/test/path")
+        );
+        // Trailing separators are ignored.
+        assert_eq!(
+            confine(root, Path::new("test/path/")).unwrap(),
+            PathBuf::from("/ceremony/test/path")
+        );
+        // A path that fully cancels out resolves to the root itself.
+        assert_eq!(
+            confine(root, Path::new("test/path/../../")).unwrap(),
+            PathBuf::from("/ceremony")
+        );
+        assert_eq!(
+            confine(root, Path::new(".")).unwrap(),
+            PathBuf::from("/ceremony")
+        );
+    }
+
+    #[test]
+    fn confine_rejects_escapes_absolute_and_empty() {
+        let root = Path::new("/ceremony");
+        assert_eq!(
+            confine(root, Path::new("../secret")),
+            Err(PathSafetyError::Traversal)
+        );
+        assert_eq!(
+            confine(root, Path::new("keys/../../secret")),
+            Err(PathSafetyError::Traversal)
+        );
+        // Escapes are rejected even when later segments would "come back".
+        assert_eq!(
+            confine(root, Path::new("../ceremony/keys")),
+            Err(PathSafetyError::Traversal)
+        );
+        assert_eq!(
+            confine(root, Path::new("/etc/passwd")),
+            Err(PathSafetyError::NotRelative)
+        );
+        assert_eq!(confine(root, Path::new("")), Err(PathSafetyError::Empty));
+    }
+}

--- a/crates/rite-resolver/Cargo.toml
+++ b/crates/rite-resolver/Cargo.toml
@@ -20,6 +20,7 @@ thiserror = { workspace = true }
 indexmap = { workspace = true }
 
 [dev-dependencies]
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/rite-resolver/src/diagnostic.rs
+++ b/crates/rite-resolver/src/diagnostic.rs
@@ -291,14 +291,18 @@ impl SpanMap {
             ResolveError::Io { .. }
             | ResolveError::UnsupportedVersion { .. }
             | ResolveError::DutyUnknownRole { .. }
-            | ResolveError::CustomDutyMissingDescription { .. } => None,
+            | ResolveError::CustomDutyMissingDescription { .. }
+            | ResolveError::UnsafeArtifactId { .. }
+            | ResolveError::UnsafeMaterialPath { .. } => None,
             ResolveError::DuplicateRole(id) => self.roles.get(id).copied(),
             ResolveError::DuplicateStep(id) => self.steps.get(id).copied(),
             ResolveError::DuplicateSection(id) => self.sections.get(id).copied(),
             ResolveError::DuplicateAct(id) => self.acts.get(id).copied(),
             ResolveError::DuplicateParam(id) => self.params.get(id).copied(),
             ResolveError::DuplicateMaterial(id) => self.materials.get(id).copied(),
-            ResolveError::DuplicateOutput(id) => self.outputs.get(id).copied(),
+            ResolveError::DuplicateOutput(id) | ResolveError::UnsafeOutputId { id, .. } => {
+                self.outputs.get(id).copied()
+            }
             ResolveError::UnknownSection { step, .. }
             | ResolveError::UnknownArtifact { step, .. }
             | ResolveError::MissingRequiredBackend { step, .. }

--- a/crates/rite-resolver/src/error.rs
+++ b/crates/rite-resolver/src/error.rs
@@ -243,6 +243,45 @@ pub enum ResolveError {
         value: String,
     },
 
+    /// An artifact id (from a step's `creates:`) is not a safe filename.
+    ///
+    /// Artifact ids become output filenames, so they must be plain names with no
+    /// path separators or `..` traversal.
+    #[error("Artifact id '{id}' is not a valid name: {reason}")]
+    UnsafeArtifactId {
+        /// The offending artifact id.
+        id: ArtifactId,
+        /// Why it was rejected.
+        reason: String,
+    },
+
+    /// An output id (an `output:` key) is not a safe filename.
+    ///
+    /// Output ids become filenames in the run directory, so they must be plain
+    /// names with no path separators or `..` traversal.
+    #[error("Output id '{id}' is not a valid name: {reason}")]
+    UnsafeOutputId {
+        /// The offending output id.
+        id: OutputId,
+        /// Why it was rejected.
+        reason: String,
+    },
+
+    /// A material's `path:` escapes the ceremony directory.
+    ///
+    /// Paths embedded in a ceremony file are confined to the directory that
+    /// contains the ceremony; absolute paths or `..` traversal are rejected.
+    /// Provide out-of-tree files via `--material name=@/path` instead.
+    #[error("Material '{material}' path '{path}' is not allowed: {reason}")]
+    UnsafeMaterialPath {
+        /// The material whose path was rejected.
+        material: MaterialId,
+        /// The offending path.
+        path: PathBuf,
+        /// Why it was rejected.
+        reason: String,
+    },
+
     /// Reference type mismatch in a field.
     #[error(
         "Reference type mismatch in '{context}' field '{field}': expected {expected}, got {actual}"

--- a/crates/rite-resolver/src/lib.rs
+++ b/crates/rite-resolver/src/lib.rs
@@ -64,22 +64,61 @@ impl CeremonyInputs {
     }
 }
 
-/// Resolve relative `path:` values in digital materials against the ceremony file's directory.
+/// Resolve `path:` values in digital materials against the ceremony file's directory,
+/// confining them to that directory's subtree.
 ///
-/// Called after `lower_ceremony` succeeds. CLI-provided `@path` values are already resolved
-/// relative to CWD in `parse_material_value`; those are not touched here.
-fn resolve_material_paths(ceremony: &mut schema::Ceremony, ceremony_path: &Path) {
+/// Called after `lower_ceremony` succeeds. Paths embedded in the ceremony file are
+/// untrusted (the file may have been authored elsewhere), so a `path:` that is absolute
+/// or climbs out of the ceremony directory via `..` is rejected rather than read.
+/// Out-of-tree files are still reachable by passing `--material name=@/path`, which is
+/// operator-supplied and resolved relative to CWD in `parse_material_value` — those never
+/// reach this function.
+///
+/// Returns one [`ResolveError::UnsafeMaterialPath`] per rejected path; the caller surfaces
+/// them alongside resolution errors.
+fn resolve_material_paths(
+    ceremony: &mut schema::Ceremony,
+    ceremony_path: &Path,
+) -> Vec<ResolveError> {
     let dir = ceremony_path.parent().unwrap_or_else(|| Path::new("."));
-    for material in ceremony.materials.values_mut() {
+    let mut errors = Vec::new();
+    for (name, material) in &mut ceremony.materials {
         if let schema::Material::Digital {
             path: Some(ref mut p),
             ..
         } = *material
-            && p.is_relative()
         {
-            *p = dir.join(&*p);
+            match rite_model::confine(dir, p) {
+                Ok(confined) => *p = confined,
+                Err(e) => errors.push(ResolveError::UnsafeMaterialPath {
+                    material: rite_model::MaterialId::new(name.as_str()),
+                    path: std::mem::take(p),
+                    reason: e.to_string(),
+                }),
+            }
         }
     }
+    errors
+}
+
+/// Confine material `path:` values, resolve the ceremony, and fold any path
+/// errors into the result.
+///
+/// Shared by [`resolve_files`] and [`analyze`], which both own a lowered
+/// ceremony and need its embedded paths confined before resolution. A non-empty
+/// set of path errors fails the result, so `value` is cleared alongside.
+fn resolve_with_material_paths(
+    mut ceremony: schema::Ceremony,
+    ceremony_path: &Path,
+    inputs: Option<&CeremonyInputs>,
+) -> ResolveResult<rite_model::Ceremony> {
+    let path_errors = resolve_material_paths(&mut ceremony, ceremony_path);
+    let mut result = resolve::resolve_ceremony(ceremony, inputs);
+    if !path_errors.is_empty() {
+        result.value = None;
+        result.errors.extend(path_errors);
+    }
+    result
 }
 
 /// Extract the first error diagnostic as a `ResolveError`, or return a generic parse failure.
@@ -132,12 +171,11 @@ pub fn resolve_files(
 
     let (ceremony_opt, _span_map, diags) = lower::lower_ceremony(Some(ceremony_path), &yaml);
 
-    let Some(mut ceremony) = ceremony_opt else {
+    let Some(ceremony) = ceremony_opt else {
         return ResolveResult::err(first_resolve_error(diags));
     };
 
-    resolve_material_paths(&mut ceremony, ceremony_path);
-    resolve::resolve_ceremony(ceremony, inputs)
+    resolve_with_material_paths(ceremony, ceremony_path, inputs)
 }
 
 /// Parse and validate ceremony YAML from an in-memory string.
@@ -193,12 +231,11 @@ pub fn analyze(
 
     let (ceremony_opt, span_map, mut diags) = lower::lower_ceremony(Some(ceremony_path), &yaml);
 
-    let Some(mut ceremony) = ceremony_opt else {
+    let Some(ceremony) = ceremony_opt else {
         return (None, diags);
     };
 
-    resolve_material_paths(&mut ceremony, ceremony_path);
-    let result = resolve::resolve_ceremony(ceremony, inputs);
+    let result = resolve_with_material_paths(ceremony, ceremony_path, inputs);
 
     for e in &result.errors {
         diags.push(span_map.to_diagnostic(Some(ceremony_path), e));
@@ -216,6 +253,60 @@ mod tests {
     use super::*;
     use crate::test_helpers::span_text;
     use rite_model::{ParamId, RoleId};
+
+    #[test]
+    fn rejects_material_path_escaping_ceremony_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ceremony_path = dir.path().join("c.rite.yaml");
+        std::fs::write(
+            &ceremony_path,
+            r#"
+version: "0.2"
+name: "Test"
+roles: {}
+sections: {}
+materials:
+  leaked:
+    type: digital
+    path: "../../../../etc/passwd"
+"#,
+        )
+        .expect("write ceremony");
+
+        let result = resolve_files(&ceremony_path, None);
+        assert!(result.is_err());
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| matches!(e, ResolveError::UnsafeMaterialPath { .. })),
+            "expected UnsafeMaterialPath, got {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn confines_relative_material_path_to_ceremony_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ceremony_path = dir.path().join("c.rite.yaml");
+        std::fs::write(
+            &ceremony_path,
+            r#"
+version: "0.2"
+name: "Test"
+roles: {}
+sections: {}
+materials:
+  local:
+    type: digital
+    path: "keys/root.pem"
+"#,
+        )
+        .expect("write ceremony");
+
+        let result = resolve_files(&ceremony_path, None);
+        assert!(result.is_ok(), "Errors: {:?}", result.errors);
+    }
 
     #[test]
     fn resolve_minimal_ceremony() {
@@ -681,6 +772,20 @@ output:
             DISPATCH_YAML,
             &span_map,
             &ResolveError::DuplicateOutput(OutputId::new("signed_cert")),
+        );
+        assert_eq!(text, "signed_cert");
+    }
+
+    #[test]
+    fn dispatch_unsafe_output_id_spans_output_declaration() {
+        let span_map = span_map_for(DISPATCH_YAML);
+        let text = dispatch_span_text(
+            DISPATCH_YAML,
+            &span_map,
+            &ResolveError::UnsafeOutputId {
+                id: OutputId::new("signed_cert"),
+                reason: "name must not contain a path separator ('/' or '\\')".to_string(),
+            },
         );
         assert_eq!(text, "signed_cert");
     }

--- a/crates/rite-resolver/src/resolve.rs
+++ b/crates/rite-resolver/src/resolve.rs
@@ -265,6 +265,13 @@ impl ResolveContext {
     fn register_outputs(&mut self, outputs: &HashMap<String, schema::OutputDeclaration>) {
         for (name, output) in outputs {
             let id = OutputId::new(name);
+            if let Err(e) = rite_model::validate_component(name) {
+                self.add_error(ResolveError::UnsafeOutputId {
+                    id: id.clone(),
+                    reason: e.to_string(),
+                });
+                continue;
+            }
             let resolved = Output {
                 id: id.clone(),
                 kind: output.artifact_type,
@@ -491,11 +498,18 @@ impl ResolveContext {
 
                 let (reads, reads_resolved) = self.resolve_inputs(step.reads.as_ref(), &id);
 
-                let creates = step.creates.as_ref().map(|p| {
+                let creates = step.creates.as_ref().and_then(|p| {
                     let artifact_id = ArtifactId::new(extract_name(p));
+                    if let Err(e) = rite_model::validate_component(artifact_id.as_str()) {
+                        self.add_error(ResolveError::UnsafeArtifactId {
+                            id: artifact_id.clone(),
+                            reason: e.to_string(),
+                        });
+                        return None;
+                    }
                     self.produced_artifacts
                         .insert(artifact_id.clone(), id.clone());
-                    artifact_id
+                    Some(artifact_id)
                 });
 
                 let with_json = step
@@ -891,6 +905,53 @@ mod tests {
         let ceremony = minimal_ceremony();
         let result = resolve_ceremony(ceremony, None);
         assert!(result.is_ok(), "Errors: {:?}", result.errors);
+    }
+
+    #[test]
+    fn rejects_creates_with_path_traversal() {
+        let mut ceremony = minimal_ceremony();
+        let mut step = make_step_body();
+        step.creates = Some("../../../etc/cron.d/x".to_string());
+        ceremony
+            .sections
+            .get_mut("main")
+            .unwrap()
+            .steps
+            .insert("gen".to_string(), step);
+
+        let result = resolve_ceremony(ceremony, None);
+        assert!(result.is_err());
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| matches!(e, ResolveError::UnsafeArtifactId { .. })),
+            "expected UnsafeArtifactId, got {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn rejects_output_id_with_separator() {
+        let mut ceremony = minimal_ceremony();
+        ceremony.output.insert(
+            "../escape".to_string(),
+            schema::OutputDeclaration {
+                artifact_type: rite_model::OutputType::PublicKey,
+                description: None,
+            },
+        );
+
+        let result = resolve_ceremony(ceremony, None);
+        assert!(result.is_err());
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| matches!(e, ResolveError::UnsafeOutputId { .. })),
+            "expected UnsafeOutputId, got {:?}",
+            result.errors
+        );
     }
 
     #[test]

--- a/crates/rite-runtime/src/executor.rs
+++ b/crates/rite-runtime/src/executor.rs
@@ -8,7 +8,8 @@ use rite_model::{ActionType, ArtifactId, Material, MaterialKind, MaterialSource,
 use rite_sdk::BackendError;
 use std::fs;
 use std::io;
-use std::path::PathBuf;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 use crate::output_config::OutputConfig;
@@ -125,6 +126,25 @@ pub(crate) fn load_material_artifact(
     }
 }
 
+/// Write `bytes` to a freshly created file at `path`, failing if anything already exists there.
+///
+/// Uses `create_new` so the write cannot follow a pre-existing symlink planted at the
+/// destination (which could otherwise redirect artifact bytes outside the run directory) and
+/// cannot clobber an existing file. On Unix the file is created with `0o600` so artifact
+/// material is not world-readable.
+fn write_new_file(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path)?;
+    file.write_all(bytes)?;
+    file.sync_all()
+}
+
 /// Serialize an artifact, write it to disk, and return `(path, sha256-hex, size-bytes, mime-type)`.
 pub(crate) fn write_artifact_to_disk(
     artifact_id: &ArtifactId,
@@ -139,9 +159,14 @@ pub(crate) fn write_artifact_to_disk(
                 reason: e,
             })?;
 
-    let path = output_config.artifact_path(artifact_id.as_str(), serialized.extension);
+    let path = output_config
+        .artifact_path(artifact_id.as_str(), serialized.extension)
+        .map_err(|e| ExecutionError::OutputWriteFailed {
+            name: artifact_id.as_str().to_string(),
+            reason: e.to_string(),
+        })?;
 
-    fs::write(&path, &serialized.bytes).map_err(|e| ExecutionError::OutputWriteFailed {
+    write_new_file(&path, &serialized.bytes).map_err(|e| ExecutionError::OutputWriteFailed {
         name: artifact_id.as_str().to_string(),
         reason: e.to_string(),
     })?;

--- a/crates/rite-runtime/src/output_config.rs
+++ b/crates/rite-runtime/src/output_config.rs
@@ -1,6 +1,7 @@
 //! Configuration for ceremony output directory structure.
 
 use chrono::Utc;
+use rite_model::{PathSafetyError, safe_join};
 use std::path::PathBuf;
 
 /// Configuration for ceremony output directory structure.
@@ -70,8 +71,17 @@ impl OutputConfig {
     }
 
     /// Returns the path for an artifact with the given ID and extension.
-    pub fn artifact_path(&self, id: &str, extension: &str) -> PathBuf {
-        self.artifacts_dir().join(format!("{id}.{extension}"))
+    ///
+    /// The id is treated as untrusted: it becomes a filename directly inside the
+    /// artifacts directory, so this rejects any id that contains a path
+    /// separator or `..` traversal. The resolver already validates artifact ids
+    /// at load time; this is the defense-in-depth check at the filesystem
+    /// boundary so a future code path cannot reintroduce a traversal.
+    ///
+    /// # Errors
+    /// Returns [`PathSafetyError`] if `id` is not a safe single filename.
+    pub fn artifact_path(&self, id: &str, extension: &str) -> Result<PathBuf, PathSafetyError> {
+        safe_join(&self.artifacts_dir(), &format!("{id}.{extension}"))
     }
 }
 
@@ -108,9 +118,17 @@ mod tests {
             PathBuf::from("/tmp/ceremony-20251229T143022/transcript.jsonl")
         );
         assert_eq!(
-            config.artifact_path("wrapped_key", "bin"),
+            config.artifact_path("wrapped_key", "bin").unwrap(),
             PathBuf::from("/tmp/ceremony-20251229T143022/artifacts/wrapped_key.bin")
         );
+    }
+
+    #[test]
+    fn artifact_path_rejects_traversal() {
+        let config = OutputConfig::new(PathBuf::from("/tmp/ceremony"));
+        assert!(config.artifact_path("../../etc/passwd", "txt").is_err());
+        assert!(config.artifact_path("sub/dir", "txt").is_err());
+        assert!(config.artifact_path("/abs", "txt").is_err());
     }
 
     #[test]

--- a/docs/development/crate-layout.md
+++ b/docs/development/crate-layout.md
@@ -52,5 +52,29 @@ flowchart TD
   (`ExecEvent`, `UiCommand`) and on `rite-model` for the persisted types
   they render. They never reach into `rite-stdlib` or backend crates.
 
+## Path safety
+
+A ceremony file is untrusted input: it may be downloaded and run by an
+operator who never read it. Any string that originates in a ceremony and
+reaches the filesystem — an artifact id that becomes an output filename, a
+material's `path:` value — must be confined so it cannot escape the directory
+it belongs in (`../../…` traversal, an absolute path, or a symlink planted at
+the destination).
+
+Do not hand-roll these checks. Route every ceremony-derived path through
+[`rite_model::safe_path`](../../crates/rite-model/src/safe_path.rs):
+
+- `validate_component` / `safe_join` for a value that must be a single
+  filename (artifact and output ids). The resolver validates these at load
+  time; `OutputConfig::artifact_path` re-checks at the filesystem boundary so
+  a new code path cannot reintroduce a traversal.
+- `confine` for a value that may legitimately be a relative subpath but must
+  stay within a known root (material `path:` under the ceremony directory).
+
+These helpers are purely lexical. When *creating* a file at a confined path,
+also open it with `create_new` (see `executor::write_new_file`) so a
+pre-planted symlink cannot redirect the write and an existing file is never
+clobbered.
+
 For the contract between the runtime and a frontend, see
 [`runtime-and-frontend.md`](./runtime-and-frontend.md).


### PR DESCRIPTION
A ceremony file is untrusted: artifact/output ids became output filenames verbatim and material `path:` values were joined unchecked, so a crafted ceremony could write or read outside the run directory. 

Add a shared `rite_model::safe_path` helper (validate single components, confine relative paths to a root) and apply it: the resolver rejects unsafe ids and material paths at load time, `OutputConfig::artifact_path` re-checks at the filesystem boundary, and artifact writes use `create_new` + 0600 so a planted symlink cannot redirect them.
