### PR TITLE
fix(security): assorted hardening across crates

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,27 @@
+# cargo-audit configuration.
+#
+# Run via `cargo audit` (and in CI). Advisories listed under `ignore` are
+# suppressed with a documented rationale below; each entry must state why it
+# does not apply here and the condition under which it must be revisited.
+
+[advisories]
+ignore = [
+    # RUSTSEC-2023-0071 — "Marvin Attack": potential key recovery through
+    # timing sidechannels in the `rsa` crate. No fixed version is available
+    # upstream.
+    #
+    # Why it does not apply here: the `rsa` crate is pulled in only for
+    # *public-key* operations — verifying the self-signature on an incoming
+    # CSR (`rsa::RsaPublicKey::verify` in
+    # `crates/rite-stdlib/src/pki/issue_certificate.rs`). The Marvin attack
+    # targets RSA *private-key* decryption/signing (PKCS#1 v1.5 unpadding),
+    # which is never performed: Rite holds no RSA private keys in this crate
+    # and never decrypts or signs with `rsa`. All private-key crypto lives in
+    # the OpenSSL backend (`rite-openssl`), not in the `rsa` crate.
+    #
+    # Revisit if any of the following becomes true:
+    #   - `rsa` gains a private-key code path here (decryption, signing, or
+    #     key import) — grep for `RsaPrivateKey`, `decrypt`, `sign`;
+    #   - a fixed release of `rsa` ships (drop this entry and upgrade).
+    "RUSTSEC-2023-0071",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1710,6 +1710,7 @@ dependencies = [
  "openssl",
  "rite-sdk",
  "tempfile",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ sha1 = "0.11.0"
 hkdf = "0.13.0"
 rsa = "0.9.10"
 p256 = { version = "0.13.2", features = ["ecdsa", "pkcs8"] }
+zeroize = "1.8.2"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/rite-model/src/expression.rs
+++ b/crates/rite-model/src/expression.rs
@@ -707,6 +707,28 @@ pub fn find_expressions(s: &str) -> Vec<LocatedExpression> {
 /// assert!(matches!(expr, ExprValue::Expr(_)));
 /// ```
 pub fn parse_expr_value(json: &serde_json::Value) -> ExprValue {
+    parse_expr_value_at(json, 0)
+}
+
+/// Maximum nesting depth [`parse_expr_value`] recurses into.
+///
+/// Matches the depth cap the resolver enforces on ceremony YAML, so values
+/// that went through resolution never reach this limit.
+const MAX_VALUE_DEPTH: usize = 64;
+
+/// Depth-tracking worker for [`parse_expr_value`].
+///
+/// Values nested deeper than [`MAX_VALUE_DEPTH`] are truncated to
+/// `Literal(Null)`: the function returns a value rather than a `Result`, so
+/// truncation is the least invasive way to stay total on adversarial input
+/// without overflowing the stack. The resolver rejects ceremony files nested
+/// past the same cap before values reach this function, so the truncation is
+/// a defensive backstop, not user-visible behavior.
+fn parse_expr_value_at(json: &serde_json::Value, depth: usize) -> ExprValue {
+    if depth >= MAX_VALUE_DEPTH {
+        return ExprValue::Literal(Literal::Null);
+    }
+    let child_depth = depth.saturating_add(1);
     match json {
         serde_json::Value::String(s) => parse_string_to_expr_value(s),
         serde_json::Value::Number(n) => {
@@ -724,12 +746,15 @@ pub fn parse_expr_value(json: &serde_json::Value) -> ExprValue {
         serde_json::Value::Object(map) => {
             let mut result = std::collections::HashMap::new();
             for (k, v) in map {
-                result.insert(k.clone(), parse_expr_value(v));
+                result.insert(k.clone(), parse_expr_value_at(v, child_depth));
             }
             ExprValue::Object(result)
         }
         serde_json::Value::Array(arr) => {
-            let result: Vec<_> = arr.iter().map(parse_expr_value).collect();
+            let result: Vec<_> = arr
+                .iter()
+                .map(|v| parse_expr_value_at(v, child_depth))
+                .collect();
             ExprValue::Array(result)
         }
     }
@@ -1215,6 +1240,55 @@ mod tests {
                 }
                 _ => panic!("Expected Array, got {expr:?}"),
             }
+        }
+
+        #[test]
+        fn parse_deeply_nested_value_is_truncated_not_crashed() {
+            // 200 levels of nesting: far past the cap. The function must
+            // return (no stack overflow), truncating everything below
+            // MAX_VALUE_DEPTH to Literal(Null).
+            let mut json = serde_json::json!("leaf");
+            for _ in 0..200 {
+                json = serde_json::Value::Array(vec![json]);
+            }
+            let mut expr = parse_expr_value(&json);
+            let mut levels = 0;
+            loop {
+                match expr {
+                    ExprValue::Array(mut arr) => {
+                        assert_eq!(arr.len(), 1);
+                        expr = arr.remove(0);
+                        levels += 1;
+                    }
+                    other => {
+                        assert!(
+                            matches!(other, ExprValue::Literal(Literal::Null)),
+                            "truncated tail must be Literal(Null), got {other:?}"
+                        );
+                        break;
+                    }
+                }
+            }
+            assert_eq!(levels, MAX_VALUE_DEPTH, "recursion must stop at the cap");
+        }
+
+        #[test]
+        fn parse_moderately_nested_value_is_preserved() {
+            let mut json = serde_json::json!("leaf");
+            for _ in 0..10 {
+                json = serde_json::Value::Array(vec![json]);
+            }
+            let mut expr = parse_expr_value(&json);
+            for _ in 0..10 {
+                match expr {
+                    ExprValue::Array(mut arr) => {
+                        assert_eq!(arr.len(), 1);
+                        expr = arr.remove(0);
+                    }
+                    other => panic!("expected Array, got {other:?}"),
+                }
+            }
+            assert!(matches!(expr, ExprValue::Literal(Literal::String(s)) if s == "leaf"));
         }
 
         #[test]

--- a/crates/rite-openssl/Cargo.toml
+++ b/crates/rite-openssl/Cargo.toml
@@ -19,6 +19,7 @@ vendored = ["openssl/vendored"]
 rite-sdk = { workspace = true }
 openssl = { workspace = true }
 base16ct = { workspace = true }
+zeroize = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/rite-openssl/src/backend.rs
+++ b/crates/rite-openssl/src/backend.rs
@@ -1,8 +1,10 @@
 //! OpenSSL backend implementation.
 //!
 //! Uses the `openssl` crate for all cryptographic operations. Keys are stored
-//! as OpenSSL `PKey<Private>` objects; OpenSSL manages key memory and frees
-//! it on drop (no `secrecy` crate needed).
+//! as OpenSSL `PKey<Private>` objects; OpenSSL manages that key memory and
+//! frees it on drop. Key material serialized *out* of OpenSSL (DER buffers
+//! for wrapping/unwrapping) lives in ordinary Rust allocations and is wiped
+//! explicitly with `Zeroizing` before release.
 
 use openssl::asn1::Asn1Time;
 use openssl::bn::BigNum;
@@ -20,12 +22,14 @@ use rite_sdk::{
     KeyTransportBackend, RandomBackend, SignAlgorithm, SignBackend, WrapAlgorithm, WrappedKey,
 };
 use std::collections::HashMap;
+use zeroize::Zeroizing;
 
 /// OpenSSL-based cryptographic backend.
 ///
-/// Stores keys in memory as OpenSSL `PKey<Private>` objects. The private key
-/// material is managed by OpenSSL and freed on drop; no explicit zeroization
-/// is needed since OpenSSL handles this internally.
+/// Stores keys in memory as OpenSSL `PKey<Private>` objects. That private key
+/// material is managed by OpenSSL and wiped on drop. Plaintext private-key
+/// DER produced during wrap/unwrap, however, lives in Rust-side buffers and
+/// is zeroized explicitly when dropped.
 pub struct OpenSslBackend {
     name: String,
     keys: HashMap<KeyId, StoredKey>,
@@ -516,10 +520,14 @@ impl KeyTransportBackend for OpenSslBackend {
         // A self-signed cert built from the KEK lets OpenSSL select the right
         // encapsulation: RSA KEK → RSAES-PKCS1-v1.5, EC P-256 KEK → RFC 5753 ECDH.
         let cert = self_signed_cert(&kek.pkey)?;
-        let key_material = target
-            .pkey
-            .private_key_to_der()
-            .map_err(|e| ossl_err("Export key material for wrapping", &e))?;
+        // Zeroizing: this buffer holds the plaintext private key in DER form;
+        // wipe it on drop rather than leaving it in freed heap memory.
+        let key_material = Zeroizing::new(
+            target
+                .pkey
+                .private_key_to_der()
+                .map_err(|e| ossl_err("Export key material for wrapping", &e))?,
+        );
 
         let data = cms_encrypt(cert, &key_material, algorithm)?;
         Ok(WrappedKey {
@@ -536,7 +544,9 @@ impl KeyTransportBackend for OpenSslBackend {
         label: &str,
     ) -> Result<KeyMetadata, BackendError> {
         // Scope the immutable borrow of `kek` so it ends before `store_key` needs `&mut self`.
-        let key_material = {
+        // Zeroizing: the decrypted output is the plaintext private key in DER
+        // form; wipe it on drop rather than leaving it in freed heap memory.
+        let key_material = Zeroizing::new({
             let kek = self.get_key(unwrapping_key_id)?;
             // Re-create the ephemeral cert from the same key; CMS decrypt needs it
             // to find the matching recipient.
@@ -545,7 +555,7 @@ impl KeyTransportBackend for OpenSslBackend {
                 .map_err(|e| ossl_err("Parse CMS DER", &e))?;
             cms.decrypt(&kek.pkey, &cert)
                 .map_err(|e| ossl_err("CMS decrypt", &e))?
-        };
+        });
 
         let pkey = parse_private_key_der(&key_material)?;
 
@@ -565,10 +575,14 @@ impl KeyTransportBackend for OpenSslBackend {
         // validates the cert's self-signature — the throwaway RSA signing key inside
         // cert_for_public_key works regardless of whether the recipient key is RSA or EC.
         let cert = cert_for_public_key(recipient_pub_key)?;
-        let key_material = target
-            .pkey
-            .private_key_to_der()
-            .map_err(|e| ossl_err("Export key material for wrapping", &e))?;
+        // Zeroizing: this buffer holds the plaintext private key in DER form;
+        // wipe it on drop rather than leaving it in freed heap memory.
+        let key_material = Zeroizing::new(
+            target
+                .pkey
+                .private_key_to_der()
+                .map_err(|e| ossl_err("Export key material for wrapping", &e))?,
+        );
 
         let data = cms_encrypt(cert, &key_material, algorithm)?;
         Ok(WrappedKey {

--- a/crates/rite-resolver/src/lower.rs
+++ b/crates/rite-resolver/src/lower.rs
@@ -10,6 +10,14 @@ use marked_yaml::types::MarkedScalarNode;
 use rite_model::{ActId, ArtifactId, MaterialId, OutputId, ParamId, RoleId, SectionId, StepId};
 use std::path::Path;
 
+/// Maximum nesting depth accepted in ceremony YAML.
+///
+/// Real ceremony files nest a handful of levels; 64 is far beyond any
+/// legitimate document while keeping every recursive walk over the tree
+/// (deserialization, scalar coercion, expression parsing) bounded to a
+/// stack depth that cannot overflow.
+const MAX_YAML_DEPTH: usize = 64;
+
 /// Parse ceremony YAML, build a `SpanMap`, and return structured diagnostics.
 ///
 /// Always returns whatever spans could be collected even if deserialization fails.
@@ -27,6 +35,29 @@ pub(crate) fn lower_ceremony(
             return (None, SpanMap::default(), diags);
         }
     };
+
+    // Reject pathological nesting before any recursive walk over the tree.
+    // `from_node` (Step C), `coerce_yaml_scalars`, and the expression parsing
+    // downstream all recurse over this structure; a crafted file with hundreds
+    // of nested sequences/mappings would otherwise overflow the stack and
+    // abort the process — fatal for `rite-ls`, which re-parses on every
+    // keystroke. The check itself recurses, but stops descending at the cap,
+    // so its own depth is bounded.
+    //
+    // Residual limit: `marked_yaml::parse_yaml` above also recurses while
+    // building the node tree. Flow-style nesting is stopped by the scanner's
+    // own recursion limit (~255 levels, reported as a normal `ScanError`),
+    // but block-style nesting only overflows around ~600 levels on a 2 MiB
+    // thread stack — an upstream limit this guard runs too late to prevent.
+    if exceeds_max_depth(&node, 0) {
+        diags.push(Diagnostic {
+            path: path.map(Path::to_owned),
+            span: None,
+            severity: Severity::Error,
+            message: format!("YAML nesting exceeds the maximum depth of {MAX_YAML_DEPTH} levels"),
+        });
+        return (None, SpanMap::default(), diags);
+    }
 
     // Step B: walk spans; always runs, even if Step C fails.
     let (span_map, structural_diags) = Lowerer::new(path, yaml).walk(&node);
@@ -438,6 +469,24 @@ fn mapping_has_key(map: &marked_yaml::types::MarkedMappingNode, key: &str) -> bo
     map.iter().any(|(k, _)| k.as_str() == key)
 }
 
+/// Check whether the node tree nests deeper than [`MAX_YAML_DEPTH`].
+///
+/// Returns as soon as the cap is hit, so the recursion here is bounded to
+/// `MAX_YAML_DEPTH` frames regardless of input.
+fn exceeds_max_depth(node: &Node, depth: usize) -> bool {
+    if depth >= MAX_YAML_DEPTH {
+        return true;
+    }
+    let child_depth = depth.saturating_add(1);
+    if let Some(map) = node.as_mapping() {
+        map.iter().any(|(_, v)| exceeds_max_depth(v, child_depth))
+    } else if let Some(seq) = node.as_sequence() {
+        seq.iter().any(|v| exceeds_max_depth(v, child_depth))
+    } else {
+        false
+    }
+}
+
 /// Extract a plain role ID from either `"${role.id}"` expression syntax or a bare ID.
 fn extract_role_id(raw: &str) -> &str {
     raw.strip_prefix("${role.")
@@ -512,6 +561,19 @@ fn coerce_ceremony_json_scalars(ceremony: &mut Ceremony) {
 
 /// Recursively coerce string scalars in a `serde_json::Value` to their proper types.
 fn coerce_yaml_scalars(value: &mut serde_json::Value) {
+    coerce_yaml_scalars_at(value, 0);
+}
+
+/// Depth-tracking worker for [`coerce_yaml_scalars`].
+///
+/// The depth guard in `lower_ceremony` already rejects trees nested past
+/// [`MAX_YAML_DEPTH`], so the cap here is a defensive backstop: values deeper
+/// than the cap are left uncoerced rather than recursed into.
+fn coerce_yaml_scalars_at(value: &mut serde_json::Value, depth: usize) {
+    if depth >= MAX_YAML_DEPTH {
+        return;
+    }
+    let child_depth = depth.saturating_add(1);
     match value {
         serde_json::Value::String(s) => {
             if let Some(coerced) = coerce_scalar(s) {
@@ -520,12 +582,12 @@ fn coerce_yaml_scalars(value: &mut serde_json::Value) {
         }
         serde_json::Value::Array(arr) => {
             for v in arr {
-                coerce_yaml_scalars(v);
+                coerce_yaml_scalars_at(v, child_depth);
             }
         }
         serde_json::Value::Object(map) => {
             for v in map.values_mut() {
-                coerce_yaml_scalars(v);
+                coerce_yaml_scalars_at(v, child_depth);
             }
         }
         _ => {}
@@ -1040,6 +1102,76 @@ sections:
             .get(&step_id)
             .expect("step_one should be in span map");
         assert!(span.line > 0, "span line should be set");
+    }
+
+    /// Ceremony YAML with a flow sequence nested `depth` levels under `with:`.
+    fn ceremony_with_nested_payload(depth: usize) -> String {
+        let nested = format!("{}0{}", "[".repeat(depth), "]".repeat(depth));
+        format!(
+            "version: \"0.2\"\n\
+             name: \"Test\"\n\
+             roles: {{}}\n\
+             sections:\n\
+            \x20 main:\n\
+            \x20   steps:\n\
+            \x20     s1:\n\
+            \x20       action: confirm\n\
+            \x20       with:\n\
+            \x20         payload: {nested}\n"
+        )
+    }
+
+    #[test]
+    fn deeply_nested_flow_yaml_is_rejected_with_diagnostic() {
+        // 150 levels: beyond our cap (64) but within the marked-yaml scanner's
+        // own flow recursion limit (~255), so parsing succeeds and our depth
+        // guard must reject the tree instead of letting the recursive walks
+        // overflow the stack.
+        let yaml = ceremony_with_nested_payload(150);
+        let (ceremony, _, diags) = lower_ceremony(None, &yaml);
+        assert!(ceremony.is_none(), "deeply nested ceremony must not parse");
+        let error = diags
+            .iter()
+            .find(|d| d.severity == Severity::Error)
+            .expect("should have an error diagnostic");
+        assert!(
+            error.message.contains("nesting exceeds"),
+            "diagnostic should mention the depth limit: {}",
+            error.message
+        );
+    }
+
+    #[test]
+    fn deeply_nested_block_yaml_is_rejected_with_diagnostic() {
+        // Block-style mappings nested 150 levels; the scanner's flow recursion
+        // limit does not apply to block style, so the depth guard is the only
+        // thing standing between this input and the recursive walks.
+        let mut yaml = String::from(
+            "version: \"0.2\"\nname: \"Test\"\nroles: {}\nsections:\n  main:\n    steps:\n      s1:\n        action: confirm\n        with:\n",
+        );
+        for i in 0..150 {
+            yaml.push_str(&" ".repeat(10 + i));
+            yaml.push_str("k:\n");
+        }
+        yaml.push_str(&" ".repeat(160));
+        yaml.push_str("leaf: 0\n");
+
+        let (ceremony, _, diags) = lower_ceremony(None, &yaml);
+        assert!(ceremony.is_none(), "deeply nested ceremony must not parse");
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.severity == Severity::Error && d.message.contains("nesting exceeds")),
+            "should have a depth-limit error diagnostic"
+        );
+    }
+
+    #[test]
+    fn moderate_nesting_is_accepted() {
+        let yaml = ceremony_with_nested_payload(10);
+        let (ceremony, _, diags) = lower_ceremony(None, &yaml);
+        assert!(ceremony.is_some(), "10 levels of nesting must parse");
+        assert!(diags.iter().all(|d| d.severity != Severity::Error));
     }
 
     #[test]

--- a/crates/rite-stdlib/src/verification/host.rs
+++ b/crates/rite-stdlib/src/verification/host.rs
@@ -122,36 +122,60 @@ fn get_machine_id() -> Option<String> {
     None
 }
 
+/// Run `dmesg` from a fixed absolute path and return its output.
+///
+/// The binary is resolved at `/usr/bin/dmesg` (falling back to `/bin/dmesg`),
+/// never through the inherited `PATH`: the output feeds recorded
+/// security-posture evidence, and a `PATH` shim must not be able to forge it.
+/// Returns `None` when the binary is missing or the probe fails (spawn error
+/// or non-zero exit, e.g. an unprivileged read of a restricted kernel
+/// buffer), so callers can record "probe failed" distinctly from "feature
+/// inactive".
+#[cfg(target_os = "linux")]
+fn read_dmesg() -> Option<String> {
+    let path = ["/usr/bin/dmesg", "/bin/dmesg"]
+        .into_iter()
+        .find(|p| std::path::Path::new(p).exists())?;
+    let output = std::process::Command::new(path).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
 #[cfg(target_os = "linux")]
 fn collect_security_features() -> Hardening {
-    let dmesg_out = std::process::Command::new("dmesg")
-        .output()
-        .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
-        .unwrap_or_default();
-
-    let ram_encryption = if dmesg_out.contains("AMD Memory Encryption Features active: SME") {
-        FeatureCheck::with_detail(FeatureStatus::Active, "AMD SME")
-    } else if dmesg_out.contains("x86/tme: enabled by BIOS")
-        || dmesg_out.contains("x86/mktme: enabled by BIOS")
-    {
-        FeatureCheck::with_detail(FeatureStatus::Active, "Intel TME")
-    } else {
-        let vendor = std::fs::read_to_string("/proc/cpuinfo")
-            .unwrap_or_default()
-            .lines()
-            .find(|l| l.starts_with("vendor_id"))
-            .and_then(|l| l.split(':').nth(1))
-            .map_or_else(|| "unknown".to_string(), |v| v.trim().to_string());
-        match vendor.as_str() {
-            "AuthenticAMD" => FeatureCheck::with_detail(
-                FeatureStatus::Inactive,
-                "AMD CPU; SME not supported or disabled in BIOS",
-            ),
-            "GenuineIntel" => FeatureCheck::with_detail(
-                FeatureStatus::Inactive,
-                "Intel CPU; enable TME in BIOS/UEFI Security settings",
-            ),
-            other => FeatureCheck::with_detail(FeatureStatus::Inactive, other.to_string()),
+    let ram_encryption = match read_dmesg() {
+        None => FeatureCheck::with_detail(
+            FeatureStatus::Unknown,
+            "dmesg probe failed or unavailable; RAM encryption state could not be determined",
+        ),
+        Some(dmesg_out) => {
+            if dmesg_out.contains("AMD Memory Encryption Features active: SME") {
+                FeatureCheck::with_detail(FeatureStatus::Active, "AMD SME")
+            } else if dmesg_out.contains("x86/tme: enabled by BIOS")
+                || dmesg_out.contains("x86/mktme: enabled by BIOS")
+            {
+                FeatureCheck::with_detail(FeatureStatus::Active, "Intel TME")
+            } else {
+                let vendor = std::fs::read_to_string("/proc/cpuinfo")
+                    .unwrap_or_default()
+                    .lines()
+                    .find(|l| l.starts_with("vendor_id"))
+                    .and_then(|l| l.split(':').nth(1))
+                    .map_or_else(|| "unknown".to_string(), |v| v.trim().to_string());
+                match vendor.as_str() {
+                    "AuthenticAMD" => FeatureCheck::with_detail(
+                        FeatureStatus::Inactive,
+                        "AMD CPU; SME not supported or disabled in BIOS",
+                    ),
+                    "GenuineIntel" => FeatureCheck::with_detail(
+                        FeatureStatus::Inactive,
+                        "Intel CPU; enable TME in BIOS/UEFI Security settings",
+                    ),
+                    other => FeatureCheck::with_detail(FeatureStatus::Inactive, other.to_string()),
+                }
+            }
         }
     };
 


### PR DESCRIPTION
- resolver: cap YAML nesting depth so a deeply nested ceremony returns a diagnostic instead of overflowing the stack (crashes rite-ls on keystroke).
- openssl: zeroize plaintext private-key DER buffers exposed during wrap and unwrap; correct the module comment about key-memory handling.
- runtime: strip control characters from ceremony-derived display text so a ceremony cannot inject terminal escapes into console/headless output.
- verification: probe dmesg by absolute path, not PATH, and report an indeterminate probe distinctly from an inactive feature.
- audit: document the RUSTSEC-2023-0071 ignore (rsa is verification-only).