### PR TITLE
fix(verify): harden transcript verification and entropy replay

### DIFF
--- a/crates/rite-runtime/src/entropy.rs
+++ b/crates/rite-runtime/src/entropy.rs
@@ -62,6 +62,12 @@ const VALUE_INFO_PREFIX_V1: &str = "rite/nonce/v1/";
 /// Length in bytes of an epoch seed (the HKDF pseudo-random key).
 const SEED_LEN: usize = 32;
 
+/// Longest value a single draw can produce: the `HKDF-Expand` output limit of
+/// `255 * HashLen` bytes (RFC 5869), with SHA-256's 32-byte output. [`expand`]
+/// panics beyond this, so anything replaying a recorded draw must bound the
+/// requested length by this value first.
+pub const MAX_DRAW_LEN: usize = 255 * SEED_LEN;
+
 /// `HKDF-Extract(salt, ikm)` over SHA-256, returning the 32-byte PRK.
 ///
 /// The `salt` is a fixed domain-separation constant (RFC 5869 permits a

--- a/crates/rite-runtime/src/entropy.rs
+++ b/crates/rite-runtime/src/entropy.rs
@@ -85,8 +85,10 @@ fn extract(salt: &[u8], ikm: &[u8]) -> [u8; SEED_LEN] {
 ///
 /// Never in practice. `from_prk` only rejects a PRK shorter than the hash
 /// output, but every seed here is exactly 32 bytes; `expand` only fails when
-/// `len` exceeds `255 * 32` bytes, far beyond any nonce or serial a ceremony
-/// draws. Both `expect`s therefore guard true invariants and are allowed.
+/// `len` exceeds [`MAX_DRAW_LEN`], which both untrusted entry points bound
+/// before reaching here (`Reporter::draw` on the draw side, `verify_entropy`
+/// on the replay side). Both `expect`s therefore guard true invariants and
+/// are allowed.
 #[allow(clippy::expect_used)]
 fn expand(prk: &[u8], info: &[u8], len: usize) -> Vec<u8> {
     let hk = Hkdf::<Sha256>::from_prk(prk).expect("seed is a valid HKDF PRK length");

--- a/crates/rite-runtime/src/lib.rs
+++ b/crates/rite-runtime/src/lib.rs
@@ -69,7 +69,10 @@ pub use display::{fact_summary, signal_summary, truncate_for_display};
 
 // Entropy source: the single auditable source of ceremony randomness, plus
 // the pure `rite-kdf/v1` derivation used by both the draw path and `rite verify`.
-pub use entropy::{CeremonyRandom, DERIVATION_V1, Draw, derive_value, fold_seed, initial_seed};
+pub use entropy::{
+    CeremonyRandom, DERIVATION_V1, Draw, MAX_DRAW_LEN, build_path, derive_value, fold_seed,
+    initial_seed,
+};
 
 // Reporter: action-facing handle for facts, signals, and prompts.
 pub use reporter::{Reporter, ReporterError};
@@ -79,9 +82,9 @@ pub use runner::{Action, ActionError, ActionRegistry, ExecutionSummary, Executor
 
 // Transcript sink, the durable consumer of `StepFact`s.
 pub use transcript_sink::{
-    EntropyVerified, InMemorySink, JsonlFileSink, LoadedTranscript, TranscriptFingerprint,
-    TranscriptSink, TranscriptVerified, VerifyError, read_verified_transcript, verify_entropy,
-    verify_transcript as verify_step_fact_transcript,
+    EntropyVerified, InMemorySink, JsonlFileSink, LoadedTranscript, TimedFact,
+    TranscriptFingerprint, TranscriptSink, TranscriptVerified, VerifyError,
+    read_verified_transcript, verify_entropy, verify_transcript as verify_step_fact_transcript,
 };
 
 // State (needed by `Action` implementors in downstream crates).

--- a/crates/rite-runtime/src/reporter.rs
+++ b/crates/rite-runtime/src/reporter.rs
@@ -68,6 +68,18 @@ pub enum ReporterError {
     /// so this is an internal ordering bug, never an operator-reachable state.
     #[error("internal: entropy source drawn before it was seeded")]
     Unseeded,
+    /// An action requested more bytes than a single `HKDF-Expand` can produce
+    /// ([`MAX_DRAW_LEN`](crate::entropy::MAX_DRAW_LEN) bytes). The draw side
+    /// rejects it here so the derivation fails cleanly instead of panicking
+    /// inside `expand`. Every value a ceremony draws (nonces, serials,
+    /// challenges) is far below this, so a request beyond it is an action bug.
+    #[error("entropy draw of {len} bytes exceeds the {max}-byte HKDF-Expand limit")]
+    DrawTooLong {
+        /// Requested draw length in bytes.
+        len: usize,
+        /// The `HKDF-Expand` output limit.
+        max: usize,
+    },
 }
 
 impl ReporterError {
@@ -81,6 +93,7 @@ impl ReporterError {
             ReporterError::NoCurrentStep(_) => "internal_no_current_step",
             ReporterError::DuplicateDraw { .. } => "duplicate_entropy_draw",
             ReporterError::Unseeded => "internal_entropy_unseeded",
+            ReporterError::DrawTooLong { .. } => "entropy_draw_too_long",
         };
         ErrorRecord::new(kind, self.to_string())
     }
@@ -182,6 +195,12 @@ impl<'a> Reporter<'a> {
     /// [`ReporterError::Transcript`] / [`ReporterError::Disconnected`] if the
     /// fact cannot be emitted.
     pub fn draw(&mut self, purpose: &str, len: usize) -> Result<Vec<u8>, ReporterError> {
+        if len > crate::entropy::MAX_DRAW_LEN {
+            return Err(ReporterError::DrawTooLong {
+                len,
+                max: crate::entropy::MAX_DRAW_LEN,
+            });
+        }
         let step = self
             .current_step
             .clone()
@@ -546,6 +565,24 @@ mod tests {
             }
             other => panic!("unexpected event: {other:?}"),
         }
+    }
+
+    #[test]
+    fn draw_rejects_a_length_past_the_hkdf_expand_limit() {
+        // A draw beyond MAX_DRAW_LEN would panic inside `expand`; the boundary
+        // rejects it as a recoverable error first. The length check precedes
+        // the step/seed checks, so no seeding is needed to exercise it.
+        let (event_tx, _event_rx) = unbounded();
+        let (_cmd_tx, cmd_rx) = unbounded::<UiCommand>();
+        let mut sink = InMemorySink::new();
+        let mut reporter = Reporter::new(&event_tx, &cmd_rx, &mut sink, test_clock());
+        reporter.set_current_step(Some(ids("s1")));
+
+        let err = reporter
+            .draw("oversized", crate::entropy::MAX_DRAW_LEN.saturating_add(1))
+            .expect_err("oversized draw");
+        assert!(matches!(err, ReporterError::DrawTooLong { len, .. }
+            if len == crate::entropy::MAX_DRAW_LEN + 1));
     }
 
     #[test]

--- a/crates/rite-runtime/src/runner.rs
+++ b/crates/rite-runtime/src/runner.rs
@@ -108,7 +108,8 @@ impl From<ReporterError> for ActionError {
             ReporterError::Transcript(e) => ActionError::Transcript(e),
             ReporterError::NoCurrentStep(_)
             | ReporterError::DuplicateDraw { .. }
-            | ReporterError::Unseeded => ActionError::Failed(value.to_string()),
+            | ReporterError::Unseeded
+            | ReporterError::DrawTooLong { .. } => ActionError::Failed(value.to_string()),
         }
     }
 }
@@ -137,9 +138,9 @@ impl From<ReporterError> for ExecutionError {
             }
             ReporterError::Transcript(e) => ExecutionError::TranscriptError(e.to_string()),
             ReporterError::NoCurrentStep(_) => ExecutionError::TranscriptError(value.to_string()),
-            ReporterError::DuplicateDraw { .. } | ReporterError::Unseeded => {
-                ExecutionError::EntropyError(value.to_string())
-            }
+            ReporterError::DuplicateDraw { .. }
+            | ReporterError::Unseeded
+            | ReporterError::DrawTooLong { .. } => ExecutionError::EntropyError(value.to_string()),
         }
     }
 }

--- a/crates/rite-runtime/src/transcript_sink.rs
+++ b/crates/rite-runtime/src/transcript_sink.rs
@@ -31,6 +31,7 @@
 //! - [`JsonlFileSink`], writes to disk, flushes after every line.
 //! - [`InMemorySink`], collects facts in a `Vec` for tests and tooling.
 
+use std::collections::HashSet;
 use std::fs::{File, OpenOptions};
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
@@ -322,6 +323,12 @@ pub enum VerifyError {
     /// `EntropySeeded` fact established the source.
     #[error("entropy source used before it was seeded")]
     SeedMissing,
+    /// A second `EntropySeeded` fact appeared. The source is seeded exactly
+    /// once at ceremony start; accepting a re-seed would let a crafted
+    /// transcript swap the seed mid-stream and have later draws "verify"
+    /// against a seed of the forger's choosing.
+    #[error("entropy source seeded more than once")]
+    DuplicateSeed,
     /// The seed fact declares a derivation scheme the verifier does not
     /// recognise. Never trust an unknown scheme (the JWT-`alg` lesson).
     #[error("unknown entropy derivation scheme: {0}")]
@@ -334,6 +341,50 @@ pub enum VerifyError {
     #[error("entropy draw at path '{path}' does not match re-derived value")]
     DrawMismatch {
         /// Derivation path of the mismatched draw.
+        path: String,
+    },
+    /// A recorded draw is longer than `HKDF-Expand` can produce
+    /// ([`MAX_DRAW_LEN`](crate::entropy::MAX_DRAW_LEN) bytes), so it cannot
+    /// have come from the real source. Rejected up front: attempting the
+    /// re-derivation would abort the verifier instead of failing the check.
+    #[error(
+        "entropy draw at path '{path}' records {len} bytes, beyond the {max}-byte HKDF-Expand limit"
+    )]
+    DrawTooLong {
+        /// Derivation path of the oversized draw.
+        path: String,
+        /// Recorded value length in bytes.
+        len: usize,
+        /// The `HKDF-Expand` output limit.
+        max: usize,
+    },
+    /// A draw's recorded path does not start with the
+    /// `<epoch>/<step>/` prefix the verifier rebuilds from its own fold
+    /// count and the step named on the fact, so the draw is attributed to
+    /// the wrong epoch or step.
+    #[error("entropy draw path '{path}' does not match expected '{expected_prefix}<purpose>'")]
+    PathMismatch {
+        /// Recorded derivation path.
+        path: String,
+        /// The `<epoch>/<step>/` prefix the verifier expected.
+        expected_prefix: String,
+    },
+    /// A contribution's recorded epoch does not match its position in the
+    /// fold sequence (first contribution is epoch 1, and so on).
+    #[error("entropy contribution at step '{step}' records epoch {recorded}, expected {expected}")]
+    EpochMismatch {
+        /// Step that recorded the contribution.
+        step: String,
+        /// Epoch index recorded on the fact.
+        recorded: u32,
+        /// Epoch index implied by the fold count.
+        expected: u32,
+    },
+    /// The same derivation path was drawn twice. The runtime never reuses a
+    /// path, so a duplicate means the record was edited or replayed.
+    #[error("entropy draw path '{path}' recorded more than once")]
+    DuplicateDrawPath {
+        /// The repeated derivation path.
         path: String,
     },
 }
@@ -431,6 +482,11 @@ pub struct EntropyVerified {
     /// Derivation-scheme tag declared by the seed fact, if the ceremony used
     /// the source at all.
     pub derivation: Option<String>,
+    /// Provenance of the machine seed as recorded by the seed fact (e.g.
+    /// `os`, or the `dry-run` sentinel). Consumers surface this so a
+    /// dry-run transcript, which re-derives just as cleanly as a real one,
+    /// is never presented as real evidence.
+    pub source: Option<String>,
     /// Number of human contributions folded into the ratchet.
     pub contributions: usize,
     /// Number of drawn values that re-derived to their recorded value.
@@ -445,23 +501,50 @@ pub struct EntropyVerified {
 /// value from the recorded path and checks it against the recorded value. A
 /// tampered seed, contribution, path, or value fails the check.
 ///
+/// Beyond the value re-derivation, the replay enforces the source's own
+/// invariants, so a transcript cannot record a fact stream the runtime could
+/// never have produced:
+///
+/// - the source is seeded exactly once;
+/// - each contribution's recorded `epoch` matches its position in the fold
+///   sequence;
+/// - each draw's recorded path carries the `<epoch>/<step>/` prefix rebuilt
+///   from the verifier's own fold count and the step named on the fact;
+/// - no derivation path is drawn twice;
+/// - no recorded value exceeds what `HKDF-Expand` can produce
+///   ([`MAX_DRAW_LEN`](crate::entropy::MAX_DRAW_LEN) bytes), which would
+///   otherwise abort the verifier instead of failing the check.
+///
 /// The caller is expected to have chain-verified the facts first (via
 /// [`read_verified_transcript`]); this function only re-derives.
 ///
 /// # Errors
 ///
 /// Returns a [`VerifyError`] variant describing the first inconsistency:
-/// [`VerifyError::SeedMissing`], [`VerifyError::UnknownDerivation`],
-/// [`VerifyError::MalformedEntropy`], or [`VerifyError::DrawMismatch`].
+/// [`VerifyError::SeedMissing`], [`VerifyError::DuplicateSeed`],
+/// [`VerifyError::UnknownDerivation`], [`VerifyError::MalformedEntropy`],
+/// [`VerifyError::EpochMismatch`], [`VerifyError::PathMismatch`],
+/// [`VerifyError::DuplicateDrawPath`], [`VerifyError::DrawTooLong`], or
+/// [`VerifyError::DrawMismatch`].
 pub fn verify_entropy<'a>(
     facts: impl IntoIterator<Item = &'a StepFact>,
 ) -> Result<EntropyVerified, VerifyError> {
     let mut seed: Option<[u8; 32]> = None;
+    let mut epoch: u32 = 0;
+    let mut drawn_paths: HashSet<String> = HashSet::new();
     let mut result = EntropyVerified::default();
 
     for fact in facts {
         match fact {
-            StepFact::EntropySeeded { m, derivation, .. } => {
+            StepFact::EntropySeeded {
+                m,
+                source,
+                derivation,
+                ..
+            } => {
+                if seed.is_some() {
+                    return Err(VerifyError::DuplicateSeed);
+                }
                 if derivation != crate::entropy::DERIVATION_V1 {
                     return Err(VerifyError::UnknownDerivation(derivation.clone()));
                 }
@@ -469,18 +552,56 @@ pub fn verify_entropy<'a>(
                     .map_err(|e| VerifyError::MalformedEntropy(format!("seed m: {e}")))?;
                 seed = Some(crate::entropy::initial_seed(&m_bytes));
                 result.derivation = Some(derivation.clone());
+                result.source = Some(source.clone());
             }
-            StepFact::EntropyContributed { contribution, .. } => {
+            StepFact::EntropyContributed {
+                step,
+                epoch: recorded_epoch,
+                contribution,
+                ..
+            } => {
                 let current = seed.as_ref().ok_or(VerifyError::SeedMissing)?;
+                let expected = epoch.saturating_add(1);
+                if *recorded_epoch != expected {
+                    return Err(VerifyError::EpochMismatch {
+                        step: step.as_str().to_string(),
+                        recorded: *recorded_epoch,
+                        expected,
+                    });
+                }
                 seed = Some(crate::entropy::fold_seed(current, contribution.as_bytes()));
+                epoch = expected;
                 result.contributions = result.contributions.saturating_add(1);
             }
-            StepFact::EntropyDrawn { path, value, .. } => {
+            StepFact::EntropyDrawn {
+                step, path, value, ..
+            } => {
                 let current = seed.as_ref().ok_or(VerifyError::SeedMissing)?;
+                // Rebuild the path prefix from the verifier's own fold count
+                // and the step named on the fact; only the purpose segment is
+                // taken from the record. A draw attributed to the wrong epoch
+                // or step fails here even if its value re-derives.
+                let expected_prefix = crate::entropy::build_path(epoch, step, "");
+                if !path.starts_with(&expected_prefix) || path.len() == expected_prefix.len() {
+                    return Err(VerifyError::PathMismatch {
+                        path: path.clone(),
+                        expected_prefix,
+                    });
+                }
+                if !drawn_paths.insert(path.clone()) {
+                    return Err(VerifyError::DuplicateDrawPath { path: path.clone() });
+                }
                 // The recorded value's own length fixes how many bytes to
                 // re-derive; decoding it also rejects a malformed hex record.
                 let recorded = base16ct::lower::decode_vec(value)
                     .map_err(|e| VerifyError::MalformedEntropy(format!("draw {path}: {e}")))?;
+                if recorded.len() > crate::entropy::MAX_DRAW_LEN {
+                    return Err(VerifyError::DrawTooLong {
+                        path: path.clone(),
+                        len: recorded.len(),
+                        max: crate::entropy::MAX_DRAW_LEN,
+                    });
+                }
                 let expected = crate::entropy::derive_value(current, path, recorded.len());
                 if expected != recorded {
                     return Err(VerifyError::DrawMismatch { path: path.clone() });
@@ -715,5 +836,114 @@ mod tests {
         let facts = [drawn_fact(&seed, "issue", "0/issue/cert-serial", 9)];
         let err = verify_entropy(facts.iter()).expect_err("unseeded");
         assert!(matches!(err, VerifyError::SeedMissing));
+    }
+
+    #[test]
+    fn verify_entropy_surfaces_the_seed_source() {
+        let m = b"machine entropy bytes";
+        let v = verify_entropy([seeded_fact(m)].iter()).expect("verify");
+        assert_eq!(v.source.as_deref(), Some("os"));
+    }
+
+    #[test]
+    fn verify_entropy_rejects_a_second_seed() {
+        // A mid-stream re-seed would let a forged transcript swap the seed
+        // under later draws; the replay refuses rather than resetting.
+        let facts = [seeded_fact(b"first"), seeded_fact(b"second")];
+        let err = verify_entropy(facts.iter()).expect_err("re-seed");
+        assert!(matches!(err, VerifyError::DuplicateSeed));
+    }
+
+    #[test]
+    fn verify_entropy_rejects_an_oversized_draw_without_panicking() {
+        // 8161 bytes is one past the HKDF-Expand limit (255 * 32). Re-deriving
+        // it would panic inside `expand`; the verifier must reject it as a
+        // malformed record instead of aborting.
+        let m = b"machine entropy bytes";
+        let oversized = "ab".repeat(crate::entropy::MAX_DRAW_LEN.saturating_add(1));
+        let facts = [
+            seeded_fact(m),
+            StepFact::EntropyDrawn {
+                step: StepId::new("issue"),
+                path: "0/issue/cert-serial".to_string(),
+                value: oversized,
+            },
+        ];
+        let err = verify_entropy(facts.iter()).expect_err("oversized draw");
+        assert!(matches!(err, VerifyError::DrawTooLong { len, .. } if len == 8161));
+    }
+
+    #[test]
+    fn verify_entropy_rejects_a_draw_path_with_the_wrong_epoch() {
+        // No contribution was folded, so the draw must come from epoch 0; a
+        // recorded epoch-1 path is a stream the runtime could not produce.
+        let m = b"machine entropy bytes";
+        let seed = crate::entropy::initial_seed(m);
+        let facts = [
+            seeded_fact(m),
+            drawn_fact(&seed, "issue", "1/issue/cert-serial", 9),
+        ];
+        let err = verify_entropy(facts.iter()).expect_err("wrong epoch");
+        assert!(matches!(err, VerifyError::PathMismatch { .. }));
+    }
+
+    #[test]
+    fn verify_entropy_rejects_a_draw_path_with_the_wrong_step() {
+        let m = b"machine entropy bytes";
+        let seed = crate::entropy::initial_seed(m);
+        let facts = [
+            seeded_fact(m),
+            // Path names step `other` but the fact was recorded under `issue`.
+            drawn_fact(&seed, "issue", "0/other/cert-serial", 9),
+        ];
+        let err = verify_entropy(facts.iter()).expect_err("wrong step");
+        assert!(matches!(err, VerifyError::PathMismatch { .. }));
+    }
+
+    #[test]
+    fn verify_entropy_rejects_an_empty_purpose() {
+        let m = b"machine entropy bytes";
+        let seed = crate::entropy::initial_seed(m);
+        let facts = [seeded_fact(m), drawn_fact(&seed, "issue", "0/issue/", 9)];
+        let err = verify_entropy(facts.iter()).expect_err("empty purpose");
+        assert!(matches!(err, VerifyError::PathMismatch { .. }));
+    }
+
+    #[test]
+    fn verify_entropy_rejects_a_contribution_epoch_out_of_sequence() {
+        let m = b"machine entropy bytes";
+        let facts = [
+            seeded_fact(m),
+            StepFact::EntropyContributed {
+                step: StepId::new("roll"),
+                // First fold must record epoch 1.
+                epoch: 2,
+                contribution: "3 1 6 4 2 5".to_string(),
+            },
+        ];
+        let err = verify_entropy(facts.iter()).expect_err("epoch skip");
+        assert!(matches!(
+            err,
+            VerifyError::EpochMismatch {
+                recorded: 2,
+                expected: 1,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn verify_entropy_rejects_a_duplicate_draw_path() {
+        // The runtime never reuses a path; a repeat means the record was
+        // edited or replayed.
+        let m = b"machine entropy bytes";
+        let seed = crate::entropy::initial_seed(m);
+        let facts = [
+            seeded_fact(m),
+            drawn_fact(&seed, "issue", "0/issue/cert-serial", 9),
+            drawn_fact(&seed, "issue", "0/issue/cert-serial", 9),
+        ];
+        let err = verify_entropy(facts.iter()).expect_err("duplicate path");
+        assert!(matches!(err, VerifyError::DuplicateDrawPath { .. }));
     }
 }

--- a/crates/rite/src/verify.rs
+++ b/crates/rite/src/verify.rs
@@ -1,14 +1,27 @@
 //! `rite verify`: check a ceremony transcript's integrity.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::Args as ClapArgs;
-use rite_runtime::{VerifyError, read_verified_transcript, verify_entropy};
+use rite_model::StepFact;
+use rite_runtime::{
+    TimedFact, VerifyError, compute_file_fingerprint, read_verified_transcript, verify_entropy,
+};
+
+/// Entropy-source label the runtime records for a dry run. Such a transcript
+/// derives from a fixed, publicly-known sentinel seed and re-derives exactly
+/// like a real one, so the verifier must flag it loudly.
+const DRY_RUN_SOURCE: &str = "dry-run";
 
 #[derive(ClapArgs, Debug)]
 pub struct Args {
     /// Path to the transcript JSONL file or output folder
     pub file: PathBuf,
+    /// Accept a transcript that ends without a terminal fact. By default a
+    /// truncated transcript fails verification, because cutting a transcript
+    /// at a line boundary leaves the hash chain intact.
+    #[arg(long)]
+    pub allow_truncated: bool,
 }
 
 pub fn run(args: Args) {
@@ -19,36 +32,8 @@ pub fn run(args: Args) {
         (args.file, None)
     };
 
-    match read_verified_transcript(&transcript_path) {
-        Ok(loaded) => {
-            // The hash chain is intact. Now re-derive the entropy source so
-            // every recorded random value is proven to come from the recorded
-            // seed, not cherry-picked.
-            let entropy = match verify_entropy(loaded.facts.iter().map(|t| &t.fact)) {
-                Ok(entropy) => entropy,
-                Err(err) => {
-                    eprintln!("Verification failed: {err}");
-                    std::process::exit(1);
-                }
-            };
-
-            println!("Transcript verified.");
-            println!("  Facts:       {}", loaded.facts.len());
-            println!("  Fingerprint: {}", loaded.fingerprint);
-            if let Some(scheme) = entropy.derivation {
-                println!(
-                    "  Entropy:     {} value(s) re-derived, {} contribution(s) folded ({scheme})",
-                    entropy.values_verified, entropy.contributions,
-                );
-            }
-            if !loaded.terminated {
-                eprintln!(
-                    "  Warning:     transcript is truncated, no CeremonyCompleted or \
-                     CeremonyFailed fact at the end."
-                );
-            }
-            std::process::exit(0);
-        }
+    let loaded = match read_verified_transcript(&transcript_path) {
+        Ok(loaded) => loaded,
         Err(VerifyError::Io(e)) => {
             match (&source_dir, e.kind()) {
                 (Some(dir), std::io::ErrorKind::NotFound) => {
@@ -65,5 +50,381 @@ pub fn run(args: Args) {
             eprintln!("Verification failed: {err}");
             std::process::exit(1);
         }
+    };
+
+    // The hash chain is intact. Now re-derive the entropy source so every
+    // recorded random value is proven to come from the recorded seed, not
+    // cherry-picked.
+    let entropy = match verify_entropy(loaded.facts.iter().map(|t| &t.fact)) {
+        Ok(entropy) => entropy,
+        Err(err) => {
+            eprintln!("Verification failed: {err}");
+            std::process::exit(1);
+        }
+    };
+
+    // When pointed at a run directory, also re-hash the artifact files
+    // sitting next to the transcript against the recorded digests.
+    let artifact_checks = source_dir
+        .as_deref()
+        .map(|dir| check_artifacts(dir, loaded.facts.iter().map(|t| &t.fact)));
+
+    println!("Transcript verified.");
+    println!("  Facts:       {}", loaded.facts.len());
+    if let Some(scheme) = &entropy.derivation {
+        println!(
+            "  Entropy:     {} value(s) re-derived, {} contribution(s) folded ({scheme})",
+            entropy.values_verified, entropy.contributions,
+        );
+    }
+    if let Some(source) = &entropy.source {
+        println!("  Seed source: {source}");
+    }
+
+    let (artifacts_failed, artifacts_missing) = match &artifact_checks {
+        Some(checks) => summarize_artifacts(checks),
+        None => (false, false),
+    };
+
+    // The chain check proves internal consistency only: a complete substitute
+    // transcript verifies just as cleanly. Tying it to the witnessed ceremony
+    // takes the out-of-band comparison against the fingerprint the operators
+    // wrote down when `rite run` finished, so print it in the same shape.
+    println!();
+    println!("Transcript fingerprint: {}", loaded.fingerprint);
+    println!(
+        "The checks above prove the transcript is internally consistent. To confirm\n\
+         it is the transcript of the ceremony you witnessed, compare this fingerprint\n\
+         against the one written down at the end of the ceremony run."
+    );
+
+    let mut failed = false;
+
+    if entropy.source.as_deref() == Some(DRY_RUN_SOURCE) {
+        eprintln!();
+        eprintln!(
+            "WARNING: this transcript was produced by a DRY RUN. Its entropy seed is a\n\
+             fixed, publicly-known sentinel, so the checks above prove rehearsal\n\
+             consistency only; nothing in it is evidence of a real ceremony."
+        );
+    }
+
+    if let Some(line) = first_timestamp_regression(&loaded.facts) {
+        eprintln!();
+        eprintln!(
+            "Warning: envelope timestamps are not monotonic: line {line} is earlier \
+             than the line before it."
+        );
+    }
+
+    if artifacts_missing {
+        eprintln!();
+        eprintln!("Warning: some recorded artifacts are missing from the artifacts/ directory.");
+    }
+
+    if artifacts_failed {
+        eprintln!();
+        eprintln!("Verification failed: artifact contents do not match the recorded digests.");
+        failed = true;
+    }
+
+    if !loaded.terminated {
+        eprintln!();
+        if args.allow_truncated {
+            eprintln!(
+                "Warning: transcript is truncated (no ceremony_completed or \
+                 ceremony_failed fact at the end); accepted via --allow-truncated."
+            );
+        } else {
+            eprintln!(
+                "Verification failed: transcript is truncated, no ceremony_completed or\n\
+                 ceremony_failed fact at the end. Cutting a transcript at a line boundary\n\
+                 keeps a valid hash chain, so truncation is rejected by default. Pass\n\
+                 --allow-truncated to accept a transcript from an interrupted run."
+            );
+            failed = true;
+        }
+    }
+
+    std::process::exit(i32::from(failed));
+}
+
+/// Print the per-artifact result lines and fold the statuses into
+/// `(any_failed, any_missing)`. A mismatch or an uncheckable artifact fails
+/// verification; a missing one only warns, since artifacts are routinely
+/// moved to their destination after a ceremony.
+fn summarize_artifacts(checks: &[ArtifactCheck]) -> (bool, bool) {
+    let mut failed = false;
+    let mut missing = false;
+    if checks.is_empty() {
+        println!("  Artifacts:   none recorded");
+        return (failed, missing);
+    }
+    println!("  Artifacts:");
+    for check in checks {
+        println!("    {}", check.describe());
+        match check.status {
+            ArtifactStatus::Match => {}
+            ArtifactStatus::Missing => missing = true,
+            ArtifactStatus::Mismatch { .. } | ArtifactStatus::Error { .. } => failed = true,
+        }
+    }
+    (failed, missing)
+}
+
+/// Result of re-hashing one recorded artifact against the run directory.
+#[derive(Debug)]
+struct ArtifactCheck {
+    /// Artifact name as recorded in the transcript.
+    name: String,
+    /// Location checked, relative to the run directory.
+    location: String,
+    /// Outcome of the comparison.
+    status: ArtifactStatus,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ArtifactStatus {
+    /// On-disk bytes hash to the recorded digest.
+    Match,
+    /// File exists but its hash differs from the recorded digest.
+    Mismatch {
+        /// Fingerprint of the bytes actually on disk.
+        actual: String,
+    },
+    /// No file at the derived location.
+    Missing,
+    /// The artifact could not be checked at all (unusable recorded path,
+    /// read error). Treated as a failure, like a mismatch.
+    Error {
+        /// Why the check could not run.
+        reason: String,
+    },
+}
+
+impl ArtifactCheck {
+    fn describe(&self) -> String {
+        match &self.status {
+            ArtifactStatus::Match => format!("{}: ok ({})", self.name, self.location),
+            ArtifactStatus::Mismatch { actual } => format!(
+                "{}: MISMATCH ({}): on-disk bytes hash to {actual}",
+                self.name, self.location,
+            ),
+            ArtifactStatus::Missing => format!("{}: missing ({})", self.name, self.location),
+            ArtifactStatus::Error { reason } => format!("{}: ERROR: {reason}", self.name),
+        }
+    }
+}
+
+/// Re-hash every artifact the transcript records against the run directory.
+///
+/// The transcript is untrusted input, so the recorded path is never followed.
+/// Only its final component names the file, anchored under the run
+/// directory's `artifacts/` subdirectory; a crafted transcript therefore
+/// cannot point the verifier at files outside the directory being verified.
+fn check_artifacts<'a>(
+    dir: &Path,
+    facts: impl IntoIterator<Item = &'a StepFact>,
+) -> Vec<ArtifactCheck> {
+    facts
+        .into_iter()
+        .filter_map(|fact| {
+            let StepFact::ArtifactWritten {
+                name, path, sha256, ..
+            } = fact
+            else {
+                return None;
+            };
+            Some(check_one_artifact(dir, name, path, sha256))
+        })
+        .collect()
+}
+
+fn check_one_artifact(
+    dir: &Path,
+    name: &str,
+    recorded_path: &Path,
+    recorded_sha256: &str,
+) -> ArtifactCheck {
+    let Some(file_name) = recorded_path.file_name() else {
+        return ArtifactCheck {
+            name: name.to_string(),
+            location: String::new(),
+            status: ArtifactStatus::Error {
+                reason: format!(
+                    "recorded path '{}' has no file name",
+                    recorded_path.display(),
+                ),
+            },
+        };
+    };
+    let location = Path::new("artifacts").join(file_name);
+    let on_disk = dir.join(&location);
+    let status = if on_disk.is_file() {
+        match compute_file_fingerprint(&on_disk) {
+            Ok(actual) if digest_hex(&actual) == digest_hex(recorded_sha256) => {
+                ArtifactStatus::Match
+            }
+            Ok(actual) => ArtifactStatus::Mismatch { actual },
+            Err(e) => ArtifactStatus::Error {
+                reason: format!("could not read {}: {e}", on_disk.display()),
+            },
+        }
+    } else {
+        ArtifactStatus::Missing
+    };
+    ArtifactCheck {
+        name: name.to_string(),
+        location: location.display().to_string(),
+        status,
+    }
+}
+
+/// Bare hex digest, tolerant of the `sha256:` prefix the runtime records.
+fn digest_hex(s: &str) -> &str {
+    s.strip_prefix("sha256:").unwrap_or(s)
+}
+
+/// 1-based line number of the first fact whose envelope timestamp is earlier
+/// than its predecessor's, if any. One fact per transcript line, so a fact's
+/// index maps directly to its line number.
+fn first_timestamp_regression(facts: &[TimedFact]) -> Option<usize> {
+    facts
+        .iter()
+        .zip(facts.iter().skip(1))
+        .position(|(prev, next)| next.at < prev.at)
+        .map(|i| i.saturating_add(2))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, TimeZone, Utc};
+    use rite_model::StepId;
+    use rite_runtime::compute_fingerprint;
+
+    fn artifact_fact(path: &str, sha256: String) -> StepFact {
+        StepFact::ArtifactWritten {
+            step: StepId::new("s1"),
+            name: "root.crt".to_string(),
+            path: PathBuf::from(path),
+            sha256,
+        }
+    }
+
+    fn write_artifact(dir: &Path, file_name: &str, bytes: &[u8]) {
+        let artifacts = dir.join("artifacts");
+        std::fs::create_dir_all(&artifacts).expect("create artifacts dir");
+        std::fs::write(artifacts.join(file_name), bytes).expect("write artifact");
+    }
+
+    #[test]
+    fn artifact_with_matching_bytes_passes() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_artifact(tmp.path(), "root.crt", b"cert bytes");
+        let fact = artifact_fact(
+            "/original/run/artifacts/root.crt",
+            compute_fingerprint(b"cert bytes"),
+        );
+        let checks = check_artifacts(tmp.path(), [&fact]);
+        assert_eq!(checks.len(), 1);
+        assert_eq!(
+            checks.first().expect("one check").status,
+            ArtifactStatus::Match
+        );
+    }
+
+    #[test]
+    fn artifact_with_different_bytes_is_a_mismatch() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_artifact(tmp.path(), "root.crt", b"tampered bytes");
+        let fact = artifact_fact(
+            "/original/run/artifacts/root.crt",
+            compute_fingerprint(b"cert bytes"),
+        );
+        let checks = check_artifacts(tmp.path(), [&fact]);
+        assert!(matches!(
+            checks.first().expect("one check").status,
+            ArtifactStatus::Mismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn artifact_absent_from_disk_is_reported_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let fact = artifact_fact(
+            "/original/run/artifacts/root.crt",
+            compute_fingerprint(b"cert bytes"),
+        );
+        let checks = check_artifacts(tmp.path(), [&fact]);
+        assert_eq!(
+            checks.first().expect("one check").status,
+            ArtifactStatus::Missing
+        );
+    }
+
+    #[test]
+    fn recorded_path_is_never_followed_outside_the_run_directory() {
+        // A crafted transcript records a traversal path; only the file name
+        // is used, anchored under artifacts/, so the check looks for
+        // artifacts/passwd inside the run directory and nothing else.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let fact = artifact_fact("../../../../etc/passwd", compute_fingerprint(b"x"));
+        let checks = check_artifacts(tmp.path(), [&fact]);
+        let check = checks.first().expect("one check");
+        assert_eq!(check.location, "artifacts/passwd");
+        assert_eq!(check.status, ArtifactStatus::Missing);
+    }
+
+    #[test]
+    fn recorded_path_without_a_file_name_is_an_error() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let fact = artifact_fact("/", compute_fingerprint(b"x"));
+        let checks = check_artifacts(tmp.path(), [&fact]);
+        assert!(matches!(
+            checks.first().expect("one check").status,
+            ArtifactStatus::Error { .. }
+        ));
+    }
+
+    #[test]
+    fn digest_comparison_tolerates_the_sha256_prefix() {
+        assert_eq!(digest_hex("sha256:abcd"), "abcd");
+        assert_eq!(digest_hex("abcd"), "abcd");
+    }
+
+    fn timed(facts_seconds: &[i64]) -> Vec<TimedFact> {
+        facts_seconds
+            .iter()
+            .map(|s| TimedFact {
+                at: ts(*s),
+                fact: StepFact::CeremonyStarted {
+                    name: "t".to_string(),
+                },
+            })
+            .collect()
+    }
+
+    fn ts(seconds: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(seconds, 0).single().expect("valid time")
+    }
+
+    #[test]
+    fn monotonic_timestamps_raise_no_warning() {
+        assert_eq!(first_timestamp_regression(&timed(&[10, 10, 20])), None);
+    }
+
+    #[test]
+    fn a_backwards_timestamp_is_reported_with_its_line_number() {
+        // Line 3 (1-based) goes backwards relative to line 2.
+        assert_eq!(
+            first_timestamp_regression(&timed(&[10, 20, 15, 30])),
+            Some(3)
+        );
+    }
+
+    #[test]
+    fn empty_fact_list_raises_no_warning() {
+        assert_eq!(first_timestamp_regression(&[]), None);
     }
 }

--- a/docs/development/entropy-and-verification.md
+++ b/docs/development/entropy-and-verification.md
@@ -86,18 +86,23 @@ where bytes appear:
 
 `rite verify` first checks the SHA-256 hash chain, then re-derives the source:
 
-1. Read `entropy_seeded`; reject an unknown `derivation`; rebuild `seed_0` from
-   the recorded `m`.
+1. Read `entropy_seeded`; reject an unknown `derivation` and a second seed
+   fact; rebuild `seed_0` from the recorded `m`.
 2. Walk the facts in chain order, folding each `entropy_contributed` into the
-   running seed.
-3. For each `entropy_drawn`, recompute `HKDF-Expand(seed_epoch, info, len)` from
-   the recorded path, taking `len` from the recorded value's byte length, and
-   confirm it equals the recorded value.
+   running seed and checking its recorded `epoch` against the fold count.
+3. For each `entropy_drawn`, rebuild the `<epoch>/<step>/` path prefix from
+   the verifier's own fold count and the step named on the fact and require
+   the recorded path to match; reject a path drawn twice and a value longer
+   than `HKDF-Expand` can produce (`255 * 32` bytes); then recompute
+   `HKDF-Expand(seed_epoch, info, len)` from the recorded path, taking `len`
+   from the recorded value's byte length, and confirm it equals the recorded
+   value.
 
-A tampered seed, contribution, path, or value fails the check. Because the
-transcript is hash-chained, a naive byte edit is caught by the chain first; the
-re-derivation additionally defeats a fully re-chained forgery whose values are
-not genuinely seed-derived.
+A tampered seed, contribution, path, or value fails the check, as does a fact
+stream the runtime could never have produced (a re-seed, an epoch skip, a
+reused path). Because the transcript is hash-chained, a naive byte edit is
+caught by the chain first; the re-derivation additionally defeats a fully
+re-chained forgery whose values are not genuinely seed-derived.
 
 ## Dry runs
 


### PR DESCRIPTION
`verify_entropy` fed the recorded draw length straight into HKDF-Expand, so an over-long value aborted `rite verify`/`rite report`; reject it up front. The replay now also enforces the source's invariants (single seed, matching contribution epoch, rebuilt draw path, no duplicate paths), so a forged fact stream the runtime could never produce fails the check.

`rite verify` now fails on a truncated transcript (--allow-truncated opts back in), prints the chain-tip fingerprint for out-of-band comparison, re-hashes artifacts in a run directory against their recorded digests (using only the file name, anchored under the run dir), surfaces the seed source with a dry-run warning, and warns on non-monotonic timestamps.