### PR TITLE
feat: operator-driven retry and error taxonomy for ceremonies

### DIFF
--- a/crates/rite-model/src/ir/ceremony.rs
+++ b/crates/rite-model/src/ir/ceremony.rs
@@ -156,6 +156,30 @@ pub struct Step {
     ///
     /// When `true`, the executor auto-advances without waiting for user acknowledgment.
     pub silent: bool,
+
+    /// How the runtime treats a *transient* failure of this step.
+    ///
+    /// The DSL constrains the retry-by-default; see [`RetryPolicy`]. Absent in
+    /// the DSL means [`RetryPolicy::Prompt`].
+    pub retry: RetryPolicy,
+}
+
+/// How the runtime treats a transient (retriable) failure of a step.
+///
+/// Rite ceremonies always have a human at the console, so the default is to
+/// pause and let the operator decide, rather than burn a fixed retry budget.
+/// The DSL field constrains that default rather than enabling it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RetryPolicy {
+    /// Pause on a transient error and prompt the operator (Retry / Abort),
+    /// unlimited times. The default when the DSL omits `retry:`.
+    #[default]
+    Prompt,
+    /// Never retry: a transient error fails the step immediately. For steps
+    /// where repeated attempts are themselves security-relevant.
+    Never,
+    /// Retry up to this many total attempts, then fail. A hard cap.
+    MaxAttempts(u32),
 }
 
 /// A resolved parameter with its value.

--- a/crates/rite-model/src/lib.rs
+++ b/crates/rite-model/src/lib.rs
@@ -38,8 +38,10 @@ pub use types::{
 
 pub use ir::{
     Act, ActId, ArtifactId, ArtifactRef, Ceremony, Material, MaterialId, MaterialKind, Output,
-    OutputId, ParamId, Parameter, PostCeremonyDuty, Role, RoleId, Section, SectionId, Step, StepId,
-    StepInputs, SymbolTable,
+    OutputId, ParamId, Parameter, PostCeremonyDuty, RetryPolicy, Role, RoleId, Section, SectionId,
+    Step, StepId, StepInputs, SymbolTable,
 };
 
-pub use transcript::{ErrorRecord, Prompt, ResponseRecord, StepFact, StepOutcome, ValidatorSpec};
+pub use transcript::{
+    ErrorClass, ErrorRecord, Prompt, ResponseRecord, StepFact, StepOutcome, ValidatorSpec,
+};

--- a/crates/rite-model/src/transcript.rs
+++ b/crates/rite-model/src/transcript.rs
@@ -101,10 +101,38 @@ pub enum ResponseRecord {
     Acknowledged,
 }
 
+/// Audit classification of a bad outcome, recorded so an auditor can tell the
+/// nature of a failure apart without parsing the free-form `message`.
+///
+/// This is the *audit* taxonomy (what an auditor sees), distinct from the
+/// runtime's `Retriability` (whether a step may re-run). For a backend error
+/// the two align: a retriable error is `Environmental`. They are kept separate
+/// because some classes never map cleanly onto retriability (an `Abort` is a
+/// decision, not an error).
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorClass {
+    /// The world wasn't ready; the step's work did not happen (token absent,
+    /// loose cable, PIN required).
+    Environmental,
+    /// The ceremony's own logic concluded badly (a verification mismatch, a
+    /// refused attestation). A result, not a recoverable condition.
+    Procedural,
+    /// The run itself is compromised or the definition is broken (transcript
+    /// write failed, channel lost, unknown action, invalid params).
+    Integrity,
+    /// The operator chose to stop. Not an error at all, but recorded on the
+    /// terminal fact so abort is distinguishable from failure.
+    Abort,
+}
+
 /// Structured error record for transcript serialization.
 #[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ErrorRecord {
+    /// Audit classification of this error.
+    pub class: ErrorClass,
     /// Stable kind label (e.g. `aborted`, `step_failed`, `material_load_failed`).
     pub kind: String,
     /// Human-readable message.
@@ -113,8 +141,9 @@ pub struct ErrorRecord {
 
 impl ErrorRecord {
     /// Construct an error record.
-    pub fn new(kind: impl Into<String>, message: impl Into<String>) -> Self {
+    pub fn new(class: ErrorClass, kind: impl Into<String>, message: impl Into<String>) -> Self {
         Self {
+            class,
             kind: kind.into(),
             message: message.into(),
         }
@@ -225,6 +254,18 @@ pub enum StepFact {
         step: Option<StepId>,
         /// Verbatim deviation text.
         text: String,
+    },
+    /// A step attempt failed. Recorded per attempt, so a retried step shows
+    /// `StepAttemptFailed{attempt: 1}` followed by the operator's retry
+    /// decision and, on success, `StepCompleted`. The final attempt of a step
+    /// that the run gives up on is followed by the terminal `CeremonyFailed`.
+    StepAttemptFailed {
+        /// Step whose attempt failed.
+        step: StepId,
+        /// 1-based attempt number within this step.
+        attempt: u32,
+        /// Structured error record for the failed attempt.
+        error: ErrorRecord,
     },
     /// Step finished executing.
     StepCompleted {
@@ -629,11 +670,44 @@ mod schema_snapshot_tests {
     fn ceremony_failed() {
         assert_json(
             &StepFact::CeremonyFailed {
-                error: ErrorRecord::new("aborted", "ceremony aborted by operator"),
+                error: ErrorRecord::new(
+                    ErrorClass::Abort,
+                    "aborted",
+                    "ceremony aborted by operator",
+                ),
             },
             &json!({
                 "type": "ceremony_failed",
-                "error": { "kind": "aborted", "message": "ceremony aborted by operator" },
+                "error": {
+                    "class": "abort",
+                    "kind": "aborted",
+                    "message": "ceremony aborted by operator",
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn step_attempt_failed() {
+        assert_json(
+            &StepFact::StepAttemptFailed {
+                step: StepId::new("import_key"),
+                attempt: 1,
+                error: ErrorRecord::new(
+                    ErrorClass::Environmental,
+                    "backend_error",
+                    "Token not present",
+                ),
+            },
+            &json!({
+                "type": "step_attempt_failed",
+                "step": "import_key",
+                "attempt": 1,
+                "error": {
+                    "class": "environmental",
+                    "kind": "backend_error",
+                    "message": "Token not present",
+                },
             }),
         );
     }

--- a/crates/rite-render/src/report/data.rs
+++ b/crates/rite-render/src/report/data.rs
@@ -4,7 +4,7 @@
 //! HTML renderer and, in the future, by template engines.
 
 use chrono::{DateTime, Duration, Utc};
-use rite_model::{StepFact, StepOutcome};
+use rite_model::{ErrorClass, StepFact, StepOutcome};
 use serde::Serialize;
 use std::collections::HashMap;
 
@@ -52,10 +52,28 @@ pub enum ReportStatus {
 /// Failure summary, extracted from `CeremonyFailed`.
 #[derive(Debug, Clone, Serialize)]
 pub struct ReportFailure {
+    /// Audit classification of the failure.
+    pub class: ErrorClass,
     /// Stable error kind label.
     pub kind: String,
     /// Human-readable message.
     pub message: String,
+}
+
+/// A failed attempt of a step, recorded from `StepAttemptFailed`. Present when
+/// a step was retried (or failed terminally after exhausting its retries).
+#[derive(Debug, Clone, Serialize)]
+pub struct ReportAttempt {
+    /// 1-based attempt number within the step.
+    pub attempt: u32,
+    /// Audit classification of the attempt's error.
+    pub class: ErrorClass,
+    /// Stable error kind label.
+    pub kind: String,
+    /// Human-readable message.
+    pub message: String,
+    /// UTC timestamp when the attempt failed.
+    pub failed_at: DateTime<Utc>,
 }
 
 /// Execution record for a single ceremony step.
@@ -76,6 +94,8 @@ pub struct ReportStep {
     pub outcome_status: String,
     /// Message attached to the outcome, if any.
     pub outcome_message: Option<String>,
+    /// Failed attempts before this step succeeded or was given up on.
+    pub attempts: Vec<ReportAttempt>,
 }
 
 /// An artifact produced during the ceremony.
@@ -170,7 +190,27 @@ impl Builder {
                     completed_at: None,
                     outcome_status: "in_progress".to_string(),
                     outcome_message: None,
+                    attempts: Vec::new(),
                 });
+            }
+            StepFact::StepAttemptFailed {
+                step,
+                attempt,
+                error,
+            } => {
+                if let Some(report_step) = self
+                    .step_index
+                    .get(step.as_str())
+                    .and_then(|i| self.steps.get_mut(*i))
+                {
+                    report_step.attempts.push(ReportAttempt {
+                        attempt: *attempt,
+                        class: error.class,
+                        kind: error.kind.clone(),
+                        message: error.message.clone(),
+                        failed_at: at,
+                    });
+                }
             }
             StepFact::StepCompleted { id, outcome } => {
                 if let Some(step) = self
@@ -215,6 +255,7 @@ impl Builder {
                 self.status = ReportStatus::Failed;
                 self.completed_at = Some(at);
                 self.failure = Some(ReportFailure {
+                    class: error.class,
                     kind: error.kind.clone(),
                     message: error.message.clone(),
                 });

--- a/crates/rite-render/src/view.rs
+++ b/crates/rite-render/src/view.rs
@@ -553,6 +553,8 @@ pub struct ReportView {
     pub transcript_fingerprint: String,
     /// Failure summary, when the ceremony failed.
     pub failure: Option<FailureView>,
+    /// Failed step attempts (retries), across all steps.
+    pub attempts: Vec<AttemptView>,
     /// Recorded deviations.
     pub deviations: Vec<DeviationView>,
     /// Produced artifacts.
@@ -566,10 +568,29 @@ pub struct ReportView {
 /// A failure summary in a report.
 #[derive(Debug, Clone, Serialize)]
 pub struct FailureView {
+    /// Audit classification (environmental / procedural / integrity / abort).
+    pub class: String,
     /// Stable error kind label.
     pub kind: String,
     /// Human-readable message.
     pub message: String,
+}
+
+/// A failed step attempt (a retry) in a report.
+#[derive(Debug, Clone, Serialize)]
+pub struct AttemptView {
+    /// Step that failed.
+    pub step_id: String,
+    /// 1-based attempt number within the step.
+    pub attempt: u32,
+    /// Audit classification of the attempt's error.
+    pub class: String,
+    /// Stable error kind label.
+    pub kind: String,
+    /// Human-readable message.
+    pub message: String,
+    /// Formatted timestamp.
+    pub recorded: String,
 }
 
 /// A recorded deviation in a report.
@@ -638,6 +659,20 @@ impl ReportView {
                 sha256: a.sha256.clone(),
             })
             .collect();
+        let attempts = data
+            .steps
+            .iter()
+            .flat_map(|s| {
+                s.attempts.iter().map(move |a| AttemptView {
+                    step_id: s.step_id.clone(),
+                    attempt: a.attempt,
+                    class: error_class_label(a.class).to_string(),
+                    kind: a.kind.clone(),
+                    message: a.message.clone(),
+                    recorded: format_datetime(&a.failed_at),
+                })
+            })
+            .collect();
         let steps = data
             .steps
             .iter()
@@ -668,9 +703,11 @@ impl ReportView {
                 .map(|secs| crate::report::data::format_duration(Duration::seconds(secs))),
             transcript_fingerprint: data.transcript_fingerprint.clone(),
             failure: data.failure.as_ref().map(|f| FailureView {
+                class: error_class_label(f.class).to_string(),
                 kind: f.kind.clone(),
                 message: f.message.clone(),
             }),
+            attempts,
             deviations,
             artifacts,
             steps,
@@ -685,6 +722,19 @@ fn status_slug(status: crate::report::ReportStatus) -> &'static str {
         ReportStatus::Completed => "completed",
         ReportStatus::Failed => "failed",
         ReportStatus::InProgress => "in_progress",
+    }
+}
+
+fn error_class_label(class: rite_model::ErrorClass) -> &'static str {
+    use rite_model::ErrorClass;
+    match class {
+        ErrorClass::Environmental => "environmental",
+        ErrorClass::Procedural => "procedural",
+        ErrorClass::Integrity => "integrity",
+        ErrorClass::Abort => "abort",
+        // `ErrorClass` is `#[non_exhaustive]`; a new variant renders generically
+        // until it is given a label here.
+        _ => "unknown",
     }
 }
 

--- a/crates/rite-render/templates/report.html.jinja
+++ b/crates/rite-render/templates/report.html.jinja
@@ -32,9 +32,21 @@
 {%- endif %}
     <p><strong>Transcript fingerprint:</strong> <code>{{ report.transcript_fingerprint }}</code></p>
 {%- if report.failure %}
-    <p><strong>Failure:</strong> {{ report.failure.message }} ({{ report.failure.kind }})</p>
+    <p><strong>Failure:</strong> {{ report.failure.message }} ({{ report.failure.kind }}, {{ report.failure.class }})</p>
 {%- endif %}
   </div>
+
+{%- if report.attempts %}
+  <h2>Failed Attempts</h2>
+  <table class="attempts">
+    <thead><tr><th>Recorded</th><th>Step</th><th>Attempt</th><th>Class</th><th>Error</th></tr></thead>
+    <tbody>
+{%- for a in report.attempts %}
+      <tr><td>{{ a.recorded }}</td><td><code>{{ a.step_id }}</code></td><td>{{ a.attempt }}</td><td>{{ a.class }}</td><td>{{ a.message }} ({{ a.kind }})</td></tr>
+{%- endfor %}
+    </tbody>
+  </table>
+{%- endif %}
 
 {%- if report.deviations %}
   <h2>Deviations</h2>

--- a/crates/rite-render/templates/themes/formal.css
+++ b/crates/rite-render/templates/themes/formal.css
@@ -423,10 +423,12 @@ ul.duty-items li {
 .summary-box p {
   margin: 4px 0;
 }
-.deviations {
+.deviations,
+.attempts {
   border-left: 3px solid #9a1f1f;
 }
-.deviations thead th {
+.deviations thead th,
+.attempts thead th {
   border-bottom-color: #9a1f1f;
 }
 code, .hash {

--- a/crates/rite-resolver/src/diagnostic.rs
+++ b/crates/rite-resolver/src/diagnostic.rs
@@ -307,6 +307,7 @@ impl SpanMap {
             | ResolveError::UnknownArtifact { step, .. }
             | ResolveError::MissingRequiredBackend { step, .. }
             | ResolveError::MissingWithField { step, .. }
+            | ResolveError::InvalidRetryAttempts { step }
             | ResolveError::ArtifactNeverProduced { step, .. } => self.steps.get(step).copied(),
             ResolveError::UndeclaredBackend { step, backend } => self
                 .span_for_reference(

--- a/crates/rite-resolver/src/error.rs
+++ b/crates/rite-resolver/src/error.rs
@@ -194,6 +194,16 @@ pub enum ResolveError {
         field: &'static str,
     },
 
+    /// Step `retry: { attempts: N }` has a zero attempt budget, which can never
+    /// run the step. Use `retry: never` to forbid retries instead.
+    #[error(
+        "Step '{step}': retry attempts must be at least 1 (use 'retry: never' to forbid retries)"
+    )]
+    InvalidRetryAttempts {
+        /// The step ID.
+        step: StepId,
+    },
+
     /// Duty references an unknown role.
     #[error("Duty '{duty_id}' references unknown role '{role}'")]
     DutyUnknownRole {

--- a/crates/rite-resolver/src/resolve.rs
+++ b/crates/rite-resolver/src/resolve.rs
@@ -12,8 +12,8 @@ use rite_model::expression::RefType;
 use rite_model::expression::{Expression, Reference, parse_expr_value, parse_expression};
 use rite_model::{
     Act, ActId, ArtifactId, ArtifactRef, Ceremony, Material, MaterialId, MaterialKind,
-    MaterialSource, Metadata, Output, OutputId, ParamId, Parameter, PostCeremonyDuty, Role, RoleId,
-    Section, SectionId, Step, StepId, StepInputs, SymbolTable,
+    MaterialSource, Metadata, Output, OutputId, ParamId, Parameter, PostCeremonyDuty, RetryPolicy,
+    Role, RoleId, Section, SectionId, Step, StepId, StepInputs, SymbolTable,
 };
 use rite_model::{DutyType, ParameterType};
 use std::collections::{HashMap, HashSet};
@@ -523,6 +523,8 @@ impl ResolveContext {
                     .as_ref()
                     .map(|desc| parse_expr_value(&serde_json::Value::String(desc.clone())));
 
+                let retry = self.resolve_retry(&id, step);
+
                 let resolved = Step {
                     id: id.clone(),
                     step_label,
@@ -537,6 +539,7 @@ impl ResolveContext {
                     creates,
                     description,
                     silent: step.silent,
+                    retry,
                 };
 
                 self.validate_step_backend(&id, step, ceremony);
@@ -572,6 +575,23 @@ impl ResolveContext {
                 step: id.clone(),
                 action: step.action,
             });
+        }
+    }
+
+    /// Lower the DSL `retry:` value to a [`RetryPolicy`]. A zero attempt
+    /// budget is rejected with a diagnostic and treated as `Never`.
+    fn resolve_retry(&mut self, id: &StepId, step: &schema::StepBody) -> RetryPolicy {
+        match &step.retry {
+            None => RetryPolicy::Prompt,
+            Some(schema::RetrySpec::Never) => RetryPolicy::Never,
+            Some(schema::RetrySpec::Attempts { attempts }) => {
+                if *attempts == 0 {
+                    self.add_error(ResolveError::InvalidRetryAttempts { step: id.clone() });
+                    RetryPolicy::Never
+                } else {
+                    RetryPolicy::MaxAttempts(*attempts)
+                }
+            }
         }
     }
 
@@ -897,7 +917,122 @@ mod tests {
             reads: None,
             description: None,
             silent: false,
+            retry: None,
         }
+    }
+
+    fn resolve_step_with_retry(retry: Option<schema::RetrySpec>) -> ResolveResult<Ceremony> {
+        let mut ceremony = minimal_ceremony();
+        let mut step = make_step_body();
+        step.action = ActionType::Attest;
+        step.with = Some(serde_json::json!({ "statement": "x" }));
+        step.retry = retry;
+        ceremony
+            .sections
+            .get_mut("main")
+            .unwrap()
+            .steps
+            .insert("work".to_string(), step);
+        resolve_ceremony(ceremony, None)
+    }
+
+    fn resolved_retry(retry: Option<schema::RetrySpec>) -> RetryPolicy {
+        let resolved = resolve_step_with_retry(retry)
+            .into_result()
+            .expect("ceremony resolves");
+        resolved
+            .execution_plan
+            .iter()
+            .find(|s| s.id.as_str() == "work")
+            .expect("work step")
+            .retry
+    }
+
+    #[test]
+    fn retry_absent_defaults_to_prompt() {
+        assert_eq!(resolved_retry(None), RetryPolicy::Prompt);
+    }
+
+    #[test]
+    fn retry_never_lowers_to_never() {
+        assert_eq!(
+            resolved_retry(Some(schema::RetrySpec::Never)),
+            RetryPolicy::Never
+        );
+    }
+
+    #[test]
+    fn retry_attempts_lowers_to_max_attempts() {
+        let spec = schema::RetrySpec::Attempts { attempts: 3 };
+        assert_eq!(resolved_retry(Some(spec)), RetryPolicy::MaxAttempts(3));
+    }
+
+    #[test]
+    fn retry_attempts_zero_is_rejected() {
+        let result = resolve_step_with_retry(Some(schema::RetrySpec::Attempts { attempts: 0 }));
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| matches!(e, ResolveError::InvalidRetryAttempts { step } if step.as_str() == "work")),
+            "expected InvalidRetryAttempts: {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn retry_never_parses_from_yaml() {
+        // The untagged `RetrySpec` accepts the bare keyword form.
+        let yaml = r#"
+version: "0.2"
+name: "T"
+roles:
+  p:
+    person: "A"
+sections:
+  main:
+    role: ${role.p}
+    steps:
+      work:
+        action: attest
+        retry: never
+        with:
+          statement: "x"
+"#;
+        let resolved = crate::resolve(yaml, None).into_result().expect("resolves");
+        let step = resolved
+            .execution_plan
+            .iter()
+            .find(|s| s.id.as_str() == "work")
+            .expect("work step");
+        assert_eq!(step.retry, RetryPolicy::Never);
+    }
+
+    #[test]
+    fn retry_attempts_parses_from_yaml_flow_map() {
+        let yaml = r#"
+version: "0.2"
+name: "T"
+roles:
+  p:
+    person: "A"
+sections:
+  main:
+    role: ${role.p}
+    steps:
+      work:
+        action: attest
+        retry: {attempts: 4}
+        with:
+          statement: "x"
+"#;
+        let resolved = crate::resolve(yaml, None).into_result().expect("resolves");
+        let step = resolved
+            .execution_plan
+            .iter()
+            .find(|s| s.id.as_str() == "work")
+            .expect("work step");
+        assert_eq!(step.retry, RetryPolicy::MaxAttempts(4));
     }
 
     #[test]

--- a/crates/rite-resolver/src/schema.rs
+++ b/crates/rite-resolver/src/schema.rs
@@ -126,6 +126,88 @@ pub(crate) struct StepBody {
     /// Skip the default pause after step completion.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub(crate) silent: bool,
+    /// How a transient failure of this step is treated. Absent means the
+    /// default (prompt the operator to retry or abort).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) retry: Option<RetrySpec>,
+}
+
+/// DSL `retry:` value: either the bare keyword `never` or a `{ attempts: N }`
+/// map. Both YAML shapes parse under one key.
+///
+/// Deserialized with a hand-written visitor rather than `#[serde(untagged)]`
+/// because `serde_yaml` cannot deserialize untagged struct variants (it fails
+/// the map form). The visitor dispatches on the YAML node kind: a scalar is the
+/// keyword form, a mapping is the `attempts` form.
+#[derive(Debug, Clone)]
+pub(crate) enum RetrySpec {
+    /// `retry: never`
+    Never,
+    /// `retry: { attempts: N }`
+    Attempts {
+        /// Hard cap on total attempts.
+        attempts: u32,
+    },
+}
+
+impl Serialize for RetrySpec {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            RetrySpec::Never => serializer.serialize_str("never"),
+            RetrySpec::Attempts { attempts } => {
+                use serde::ser::SerializeMap;
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("attempts", attempts)?;
+                map.end()
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for RetrySpec {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct RetryVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for RetryVisitor {
+            type Value = RetrySpec;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("\"never\" or a mapping with an `attempts` field")
+            }
+
+            fn visit_str<E: serde::de::Error>(self, value: &str) -> Result<RetrySpec, E> {
+                match value {
+                    "never" => Ok(RetrySpec::Never),
+                    other => Err(E::custom(format!(
+                        "unknown retry keyword '{other}', expected 'never' or {{ attempts: N }}"
+                    ))),
+                }
+            }
+
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                mut map: A,
+            ) -> Result<RetrySpec, A::Error> {
+                let mut attempts: Option<u32> = None;
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "attempts" => {
+                            if attempts.is_some() {
+                                return Err(serde::de::Error::duplicate_field("attempts"));
+                            }
+                            attempts = Some(map.next_value()?);
+                        }
+                        other => return Err(serde::de::Error::unknown_field(other, &["attempts"])),
+                    }
+                }
+                let attempts =
+                    attempts.ok_or_else(|| serde::de::Error::missing_field("attempts"))?;
+                Ok(RetrySpec::Attempts { attempts })
+            }
+        }
+
+        deserializer.deserialize_any(RetryVisitor)
+    }
 }
 
 /// A parameter that can be provided when instantiating a ceremony.

--- a/crates/rite-runtime/src/display.rs
+++ b/crates/rite-runtime/src/display.rs
@@ -54,6 +54,10 @@ pub fn fact_summary(fact: &StepFact) -> Option<(Icon, String)> {
             }
             _ => Some((Icon::Checkmark, "Step completed".to_string())),
         },
+        StepFact::StepAttemptFailed { attempt, error, .. } => Some((
+            Icon::Cross,
+            format!("Attempt {attempt} failed: {}", error.message),
+        )),
         StepFact::CeremonyFailed { error, .. } => {
             Some((Icon::Cross, format!("Ceremony failed: {}", error.message)))
         }

--- a/crates/rite-runtime/src/reporter.rs
+++ b/crates/rite-runtime/src/reporter.rs
@@ -26,7 +26,7 @@
 use std::sync::Arc;
 
 use crossbeam_channel::{Receiver, Sender, TryRecvError};
-use rite_model::{ErrorRecord, Prompt, ResponseRecord, StepFact, StepId};
+use rite_model::{ErrorClass, ErrorRecord, Prompt, ResponseRecord, StepFact, StepId};
 use secrecy::ExposeSecret;
 use thiserror::Error;
 
@@ -86,16 +86,18 @@ impl ReporterError {
     /// Convert this error into an [`ErrorRecord`] suitable for the transcript.
     #[must_use]
     pub fn to_error_record(&self) -> ErrorRecord {
-        let kind = match self {
-            ReporterError::Aborted => "aborted",
-            ReporterError::Disconnected => "frontend_disconnected",
-            ReporterError::Transcript(_) => "transcript_io",
-            ReporterError::NoCurrentStep(_) => "internal_no_current_step",
-            ReporterError::DuplicateDraw { .. } => "duplicate_entropy_draw",
-            ReporterError::Unseeded => "internal_entropy_unseeded",
-            ReporterError::DrawTooLong { .. } => "entropy_draw_too_long",
+        let (class, kind) = match self {
+            ReporterError::Aborted => (ErrorClass::Abort, "aborted"),
+            ReporterError::Disconnected => (ErrorClass::Integrity, "frontend_disconnected"),
+            ReporterError::Transcript(_) => (ErrorClass::Integrity, "transcript_io"),
+            ReporterError::NoCurrentStep(_) => (ErrorClass::Integrity, "internal_no_current_step"),
+            ReporterError::DuplicateDraw { .. } => {
+                (ErrorClass::Integrity, "duplicate_entropy_draw")
+            }
+            ReporterError::Unseeded => (ErrorClass::Integrity, "internal_entropy_unseeded"),
+            ReporterError::DrawTooLong { .. } => (ErrorClass::Integrity, "entropy_draw_too_long"),
         };
-        ErrorRecord::new(kind, self.to_string())
+        ErrorRecord::new(class, kind, self.to_string())
     }
 }
 
@@ -114,6 +116,11 @@ pub struct Reporter<'a> {
     /// The run clock. Read once per fact in [`Reporter::fact`] to stamp the
     /// event time onto both the transcript line and the live UI event.
     clock: Arc<dyn Clock>,
+    /// Count of facts emitted over the whole run. The executor snapshots this
+    /// before a step attempt and compares afterwards: if the attempt emitted
+    /// any fact (a backend operation, an artifact, an entropy draw) it is no
+    /// longer safely re-executable, so a transient error is not retried.
+    facts_emitted: u64,
 }
 
 impl<'a> Reporter<'a> {
@@ -132,7 +139,15 @@ impl<'a> Reporter<'a> {
             current_step: None,
             random: None,
             clock,
+            facts_emitted: 0,
         }
+    }
+
+    /// Number of facts emitted so far in this run. Used by the executor to
+    /// detect whether a step attempt produced any evidence before failing.
+    #[must_use]
+    pub fn facts_emitted(&self) -> u64 {
+        self.facts_emitted
     }
 
     /// Install the machine seed for the entropy source.
@@ -175,6 +190,7 @@ impl<'a> Reporter<'a> {
         // the durable record and the live UI event so they never disagree.
         let at = self.clock.now();
         self.transcript.record(at, &fact)?;
+        self.facts_emitted = self.facts_emitted.saturating_add(1);
         self.event_tx
             .send(ExecEvent::Fact { at, fact })
             .map_err(|_| ReporterError::Disconnected)?;

--- a/crates/rite-runtime/src/runner.rs
+++ b/crates/rite-runtime/src/runner.rs
@@ -37,8 +37,10 @@ use std::sync::Arc;
 use crossbeam_channel::{Receiver, Sender};
 use rand::TryRng;
 use rand::rngs::SysRng;
-use rite_model::{ActId, ActionType, ArtifactId, Ceremony, MaterialId, OutputId, ParamId, RoleId};
-use rite_sdk::{Backend, BackendError};
+use rite_model::{
+    ActId, ActionType, ArtifactId, Ceremony, MaterialId, OutputId, ParamId, RoleId, Step,
+};
+use rite_sdk::{Backend, BackendError, Retriability};
 use thiserror::Error;
 
 use crate::actions::ActionMetadata;
@@ -50,13 +52,13 @@ use crate::executor::{
 };
 use crate::expressions;
 use crate::output_config::OutputConfig;
-use crate::protocol::{ExecEvent, Icon, MaterialOverview, UiCommand, UiSignal};
+use crate::protocol::{ExecEvent, Icon, MaterialOverview, Response, UiCommand, UiSignal};
 use crate::reporter::{Reporter, ReporterError};
 use crate::state::{ExecutionState, HandlerContext, StepResult};
 use crate::step_info::StepInfo;
 use crate::system_info::StartupSnapshot;
 use crate::transcript_sink::{TranscriptFingerprint, TranscriptSink};
-use rite_model::{ErrorRecord, Prompt, StepFact, StepOutcome};
+use rite_model::{ErrorClass, ErrorRecord, Prompt, RetryPolicy, StepFact, StepOutcome};
 
 /// Gather the machine entropy `m` that seeds the ceremony entropy source.
 ///
@@ -110,6 +112,28 @@ impl From<ReporterError> for ActionError {
             | ReporterError::DuplicateDraw { .. }
             | ReporterError::Unseeded
             | ReporterError::DrawTooLong { .. } => ActionError::Failed(value.to_string()),
+        }
+    }
+}
+
+impl ActionError {
+    /// Classify whether the step that failed with this error may be retried.
+    ///
+    /// Delegates to [`BackendError::retriability`] for [`ActionError::Backend`];
+    /// every other handler-level error is [`Retriability::Fatal`]. `Failed`
+    /// covers procedural failures (a `check_value` mismatch must never be
+    /// re-run, that would be tampering) as well as integrity and configuration
+    /// errors, all of which are non-retriable. `Aborted` is an operator decision
+    /// handled on the abort path and is never auto-retried, so it is classified
+    /// fatal here as a safe default.
+    #[must_use]
+    pub fn retriability(&self) -> Retriability {
+        match self {
+            ActionError::Backend(e) => e.retriability(),
+            ActionError::Aborted
+            | ActionError::Disconnected
+            | ActionError::Transcript(_)
+            | ActionError::Failed(_) => Retriability::Fatal,
         }
     }
 }
@@ -510,32 +534,15 @@ impl Executor {
             let mut params = expressions::evaluate_expr_value(&step.with, &ctx)?;
             handler.apply_defaults(&mut params, &step_info);
 
-            let backend = if let Some(name) = &step_info.backend {
-                Some(self.backend_registry.get_mut(name).map_err(|e| {
-                    ExecutionError::StepFailed {
-                        step: step_info.id.clone(),
-                        reason: e.to_string(),
-                    }
-                })?)
-            } else {
-                None
-            };
-
-            let result = handler
-                .execute(&step_info, &ctx, &params, reporter, backend)
-                .map_err(|err| match err {
-                    ActionError::Aborted => ExecutionError::StepAborted(step.id.clone()),
-                    ActionError::Disconnected => ExecutionError::StepFailed {
-                        step: step.id.clone(),
-                        reason: "frontend channel disconnected".to_string(),
-                    },
-                    ActionError::Transcript(e) => ExecutionError::TranscriptError(e.to_string()),
-                    ActionError::Backend(e) => ExecutionError::BackendError(e),
-                    ActionError::Failed(reason) => ExecutionError::StepFailed {
-                        step: step.id.clone(),
-                        reason,
-                    },
-                })?;
+            let result = execute_step_with_retry(
+                handler.as_ref(),
+                step,
+                &step_info,
+                &ctx,
+                &params,
+                reporter,
+                &mut self.backend_registry,
+            )?;
 
             // StepCompleted
             reporter.fact(StepFact::StepCompleted {
@@ -596,23 +603,133 @@ struct StepCounts {
     completed: usize,
 }
 
+/// Run one step, retrying transient failures under operator control.
+///
+/// Each attempt re-acquires the backend handle (it is moved into the handler)
+/// and snapshots the fact count beforehand: a transient error is retriable only
+/// if the attempt produced no evidence yet (the conservative re-executability
+/// gate). A retriable error within the step's [`RetryPolicy`] prompts the
+/// operator; any other failure terminates the run.
+fn execute_step_with_retry(
+    handler: &dyn Action,
+    step: &Step,
+    step_info: &StepInfo,
+    ctx: &HandlerContext,
+    params: &serde_json::Value,
+    reporter: &mut Reporter<'_>,
+    backend_registry: &mut BackendRegistry,
+) -> Result<StepResult, ExecutionError> {
+    let mut attempt: u32 = 1;
+    loop {
+        let facts_before = reporter.facts_emitted();
+
+        let backend = if let Some(name) = &step_info.backend {
+            Some(
+                backend_registry
+                    .get_mut(name)
+                    .map_err(|e| ExecutionError::StepFailed {
+                        step: step_info.id.clone(),
+                        reason: e.to_string(),
+                    })?,
+            )
+        } else {
+            None
+        };
+
+        let action_err = match handler.execute(step_info, ctx, params, reporter, backend) {
+            Ok(result) => return Ok(result),
+            // Abort is an operator decision, not an attempt failure: no
+            // StepAttemptFailed is recorded, the run terminates here.
+            Err(ActionError::Aborted) => return Err(ExecutionError::StepAborted(step.id.clone())),
+            Err(action_err) => action_err,
+        };
+
+        // Conservative re-executability gate: a step that already emitted a fact
+        // this attempt is not safely re-runnable.
+        let no_new_facts = reporter.facts_emitted() == facts_before;
+        let retriable = action_err.retriability().is_retriable() && no_new_facts;
+        let exec_err = action_error_to_execution(action_err, &step.id);
+        reporter.fact(StepFact::StepAttemptFailed {
+            step: step.id.clone(),
+            attempt,
+            error: exec_err.to_error_record(),
+        })?;
+
+        let policy_allows = match step.retry {
+            RetryPolicy::Never => false,
+            RetryPolicy::MaxAttempts(max) => attempt < max,
+            RetryPolicy::Prompt => true,
+        };
+
+        if retriable && policy_allows {
+            // Default `false`: the headless/dry-run driver answers the default,
+            // so non-interactive runs abort rather than loop on a deterministic
+            // error.
+            let answer = reporter.prompt(&Prompt::Confirm {
+                question: format!("Step {} failed: {exec_err}. Retry?", step.step_label),
+                default: Some(false),
+            })?;
+            if matches!(answer, Response::Bool(true)) {
+                attempt = attempt.saturating_add(1);
+                continue;
+            }
+        }
+        return Err(exec_err);
+    }
+}
+
+/// Map a handler-level [`ActionError`] to the execution-level error the run
+/// terminates with. `Aborted` is included for completeness; the executor
+/// special-cases it before calling this so it never records a step-attempt
+/// failure for an abort.
+fn action_error_to_execution(err: ActionError, step_id: &rite_model::StepId) -> ExecutionError {
+    match err {
+        ActionError::Aborted => ExecutionError::StepAborted(step_id.clone()),
+        ActionError::Disconnected => ExecutionError::StepFailed {
+            step: step_id.clone(),
+            reason: "frontend channel disconnected".to_string(),
+        },
+        ActionError::Transcript(e) => ExecutionError::TranscriptError(e.to_string()),
+        ActionError::Backend(e) => ExecutionError::BackendError(e),
+        ActionError::Failed(reason) => ExecutionError::StepFailed {
+            step: step_id.clone(),
+            reason,
+        },
+    }
+}
+
 impl ExecutionError {
     /// Convert this execution error into a transcript-friendly record.
+    ///
+    /// The audit `class` derives from the error's nature; for a backend error
+    /// it reuses the same retriability judgment the runtime uses for retry
+    /// (a retriable backend error is environmental).
     fn to_error_record(&self) -> ErrorRecord {
-        let kind = match self {
-            ExecutionError::ValidationFailed(_) => "validation_failed",
-            ExecutionError::StepAborted(_) => "aborted",
-            ExecutionError::Io(_) => "io",
-            ExecutionError::StepFailed { .. } => "step_failed",
-            ExecutionError::UnknownAction(_) => "unknown_action",
-            ExecutionError::InvalidParams(_) => "invalid_params",
-            ExecutionError::EntropyError(_) => "entropy_error",
-            ExecutionError::MaterialLoadFailed { .. } => "material_load_failed",
-            ExecutionError::OutputWriteFailed { .. } => "output_write_failed",
-            ExecutionError::TranscriptError(_) => "transcript_error",
-            ExecutionError::BackendError(_) => "backend_error",
+        let (class, kind) = match self {
+            ExecutionError::ValidationFailed(_) => (ErrorClass::Integrity, "validation_failed"),
+            ExecutionError::StepAborted(_) => (ErrorClass::Abort, "aborted"),
+            ExecutionError::Io(_) => (ErrorClass::Integrity, "io"),
+            ExecutionError::StepFailed { .. } => (ErrorClass::Procedural, "step_failed"),
+            ExecutionError::UnknownAction(_) => (ErrorClass::Integrity, "unknown_action"),
+            ExecutionError::InvalidParams(_) => (ErrorClass::Integrity, "invalid_params"),
+            ExecutionError::EntropyError(_) => (ErrorClass::Integrity, "entropy_error"),
+            ExecutionError::MaterialLoadFailed { .. } => {
+                (ErrorClass::Integrity, "material_load_failed")
+            }
+            ExecutionError::OutputWriteFailed { .. } => {
+                (ErrorClass::Integrity, "output_write_failed")
+            }
+            ExecutionError::TranscriptError(_) => (ErrorClass::Integrity, "transcript_error"),
+            ExecutionError::BackendError(e) => {
+                let class = if e.retriability().is_retriable() {
+                    ErrorClass::Environmental
+                } else {
+                    ErrorClass::Integrity
+                };
+                (class, "backend_error")
+            }
         };
-        ErrorRecord::new(kind, self.to_string())
+        ErrorRecord::new(class, kind, self.to_string())
     }
 }
 
@@ -656,6 +773,31 @@ mod tests {
     use super::*;
     use crate::actions::ActionCategory;
     use crate::transcript_sink::InMemorySink;
+
+    #[test]
+    fn action_error_retriability_delegates_to_backend() {
+        assert_eq!(
+            ActionError::Backend(BackendError::TokenNotPresent).retriability(),
+            Retriability::Transient,
+        );
+        assert_eq!(
+            ActionError::Backend(BackendError::PinBlocked).retriability(),
+            Retriability::Fatal,
+        );
+    }
+
+    #[test]
+    fn handler_level_errors_are_fatal() {
+        assert_eq!(ActionError::Aborted.retriability(), Retriability::Fatal);
+        assert_eq!(
+            ActionError::Disconnected.retriability(),
+            Retriability::Fatal
+        );
+        assert_eq!(
+            ActionError::Failed("check_value mismatch".into()).retriability(),
+            Retriability::Fatal,
+        );
+    }
 
     struct PingAction;
 
@@ -1012,6 +1154,227 @@ sections:
         assert!(matches!(result, Err(ExecutionError::StepAborted(_))));
     }
 
+    // ---- Retry loop tests ----
+
+    /// Test action whose first `fails_remaining` executions fail with
+    /// `error()`, then it succeeds. Optionally emits a transcript fact before
+    /// failing, to exercise the re-executability gate.
+    struct FlakyAction {
+        fails_remaining: std::sync::Mutex<u32>,
+        error: fn() -> ActionError,
+        emit_fact_before_fail: bool,
+    }
+
+    impl FlakyAction {
+        fn new(fails: u32, error: fn() -> ActionError, emit_fact_before_fail: bool) -> Arc<Self> {
+            Arc::new(Self {
+                fails_remaining: std::sync::Mutex::new(fails),
+                error,
+                emit_fact_before_fail,
+            })
+        }
+    }
+
+    impl Action for FlakyAction {
+        fn metadata(&self) -> ActionMetadata {
+            ActionMetadata {
+                action_type: ActionType::Attest,
+                description: "flaky test action",
+                category: ActionCategory::Verification,
+            }
+        }
+
+        fn execute(
+            &self,
+            _step: &StepInfo,
+            _ctx: &HandlerContext,
+            _params: &serde_json::Value,
+            reporter: &mut Reporter<'_>,
+            _backend: Option<&mut dyn Backend>,
+        ) -> Result<StepResult, ActionError> {
+            let mut remaining = self.fails_remaining.lock().expect("lock");
+            if *remaining == 0 {
+                return Ok(StepResult::completed("done".to_string()));
+            }
+            *remaining = remaining.saturating_sub(1);
+            if self.emit_fact_before_fail {
+                reporter.fact(StepFact::DeviationRecorded {
+                    step: None,
+                    text: "side effect".to_string(),
+                })?;
+            }
+            Err((self.error)())
+        }
+    }
+
+    fn transient() -> ActionError {
+        ActionError::Backend(BackendError::TokenNotPresent)
+    }
+
+    fn ceremony_with_retry(retry_clause: &str) -> Ceremony {
+        let yaml = format!(
+            r#"
+version: "0.2"
+name: "Retry"
+roles:
+  participant:
+    person: "Alice"
+sections:
+  main:
+    role: ${{role.participant}}
+    steps:
+      work:
+        action: attest
+        silent: true
+        {retry_clause}
+        with:
+          statement: "x"
+"#
+        );
+        rite_resolver::resolve(&yaml, None)
+            .into_result()
+            .expect("resolve")
+    }
+
+    /// Run `ceremony` with `action`, answering every retry `Confirm` with
+    /// `confirm_answer`. Returns the run result, the emitted facts, and the
+    /// number of retry prompts seen.
+    fn drive(
+        ceremony: Ceremony,
+        action: Arc<dyn Action>,
+        confirm_answer: bool,
+    ) -> (
+        Result<ExecutionSummary, ExecutionError>,
+        Vec<StepFact>,
+        usize,
+    ) {
+        let mut registry = ActionRegistry::new();
+        registry.register(action);
+
+        let (cmd_tx, cmd_rx) = unbounded::<UiCommand>();
+        let (event_tx, event_rx) = unbounded::<ExecEvent>();
+        let sink: Box<dyn TranscriptSink> = Box::new(InMemorySink::new());
+
+        let executor = Executor::new(
+            ceremony,
+            registry,
+            BackendRegistry::new(),
+            dry_run_output_config(),
+            true, // dry_run: skips pacing/start prompts, leaving only the retry Confirm
+            StartupSnapshot::placeholder(),
+        );
+        let join = std::thread::spawn(move || executor.run(&cmd_rx, &event_tx, sink));
+
+        let mut facts = Vec::new();
+        let mut confirms = 0usize;
+        while let Ok(ev) = event_rx.recv() {
+            match ev {
+                ExecEvent::Fact { fact, .. } => facts.push(fact),
+                ExecEvent::AwaitPrompt {
+                    prompt_id,
+                    prompt: Prompt::Confirm { .. },
+                    ..
+                } => {
+                    confirms = confirms.saturating_add(1);
+                    cmd_tx
+                        .send(UiCommand::PromptResponse {
+                            prompt_id,
+                            response: Response::Bool(confirm_answer),
+                        })
+                        .expect("send confirm");
+                }
+                _ => {}
+            }
+        }
+        let result = join.join().expect("executor join");
+        (result, facts, confirms)
+    }
+
+    fn attempt_numbers(facts: &[StepFact]) -> Vec<u32> {
+        facts
+            .iter()
+            .filter_map(|f| match f {
+                StepFact::StepAttemptFailed { attempt, .. } => Some(*attempt),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn transient_failure_is_retried_then_succeeds() {
+        let action = FlakyAction::new(1, transient, false);
+        let (result, facts, confirms) = drive(ceremony_with_retry(""), action, true);
+
+        let summary = result.expect("run ok");
+        assert_eq!(summary.steps_completed, 1);
+        assert_eq!(confirms, 1, "one retry prompt");
+        assert_eq!(attempt_numbers(&facts), vec![1]);
+        // The recorded attempt is classified environmental (a transient backend error).
+        let StepFact::StepAttemptFailed { error, .. } = facts
+            .iter()
+            .find(|f| matches!(f, StepFact::StepAttemptFailed { .. }))
+            .expect("attempt fact")
+        else {
+            unreachable!()
+        };
+        assert_eq!(error.class, ErrorClass::Environmental);
+        assert!(
+            facts
+                .iter()
+                .any(|f| matches!(f, StepFact::StepCompleted { .. }))
+        );
+    }
+
+    #[test]
+    fn retry_is_blocked_once_a_fact_was_emitted() {
+        // Transient error, but the attempt already wrote a fact: the
+        // conservative gate refuses to retry, so no prompt fires.
+        let action = FlakyAction::new(u32::MAX, transient, true);
+        let (result, facts, confirms) = drive(ceremony_with_retry(""), action, true);
+
+        assert!(result.is_err(), "run fails");
+        assert_eq!(confirms, 0, "gate blocks the retry prompt");
+        assert_eq!(attempt_numbers(&facts), vec![1]);
+        assert!(
+            facts
+                .iter()
+                .any(|f| matches!(f, StepFact::CeremonyFailed { .. }))
+        );
+    }
+
+    #[test]
+    fn retry_never_fails_immediately() {
+        let action = FlakyAction::new(u32::MAX, transient, false);
+        let (result, facts, confirms) = drive(ceremony_with_retry("retry: never"), action, true);
+
+        assert!(result.is_err());
+        assert_eq!(confirms, 0, "retry: never never prompts");
+        assert_eq!(attempt_numbers(&facts), vec![1]);
+    }
+
+    #[test]
+    fn retry_attempts_caps_total_tries() {
+        let action = FlakyAction::new(u32::MAX, transient, false);
+        let (result, facts, confirms) =
+            drive(ceremony_with_retry("retry: {attempts: 2}"), action, true);
+
+        assert!(result.is_err());
+        // Attempt 1 fails and prompts; attempt 2 fails and the cap forbids a
+        // further prompt.
+        assert_eq!(confirms, 1);
+        assert_eq!(attempt_numbers(&facts), vec![1, 2]);
+    }
+
+    #[test]
+    fn declining_the_retry_prompt_terminates() {
+        let action = FlakyAction::new(u32::MAX, transient, false);
+        let (result, facts, confirms) = drive(ceremony_with_retry(""), action, false);
+
+        assert!(result.is_err());
+        assert_eq!(confirms, 1, "prompted once, operator declined");
+        assert_eq!(attempt_numbers(&facts), vec![1]);
+    }
+
     fn fact_kind(fact: &StepFact) -> &'static str {
         match fact {
             StepFact::CeremonyStarted { .. } => "ceremony_started",
@@ -1022,6 +1385,7 @@ sections:
             StepFact::AttestationRecorded { .. } => "attestation_recorded",
             StepFact::ArtifactWritten { .. } => "artifact_written",
             StepFact::DeviationRecorded { .. } => "deviation_recorded",
+            StepFact::StepAttemptFailed { .. } => "step_attempt_failed",
             StepFact::StepCompleted { .. } => "step_completed",
             StepFact::CeremonyCompleted { .. } => "ceremony_completed",
             StepFact::CeremonyFailed { .. } => "ceremony_failed",

--- a/crates/rite-sdk/src/backend.rs
+++ b/crates/rite-sdk/src/backend.rs
@@ -432,6 +432,32 @@ pub trait YubikeyBackend: PivBackend {
     fn block_puk(&mut self) -> Result<(), BackendError>;
 }
 
+/// Whether an error may be re-executed by retrying the step.
+///
+/// A `Transient` error means the world wasn't ready and the step's work did not
+/// happen, so re-running it is meaningful (token reinserted, cable reseated). A
+/// `Fatal` error means re-execution is either meaningless or unsafe: a procedural
+/// result, a broken definition, or a terminal device state.
+///
+/// The classification lives on the error type, not in the ceremony definition: a
+/// ceremony author must not be able to mark, say, a signature mismatch retriable.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Retriability {
+    /// Environmental and recoverable; retrying the step may succeed.
+    Transient,
+    /// Not retriable; the run must stop or escalate.
+    Fatal,
+}
+
+impl Retriability {
+    /// Convenience predicate for callers that only need a yes/no answer.
+    #[must_use]
+    pub const fn is_retriable(self) -> bool {
+        matches!(self, Retriability::Transient)
+    }
+}
+
 /// Backend-specific errors.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -519,4 +545,111 @@ pub enum BackendError {
     /// Generic backend error.
     #[error("Backend error: {0}")]
     Other(String),
+}
+
+impl BackendError {
+    /// Classify whether a step that failed with this error may be retried.
+    ///
+    /// The match is exhaustive with no wildcard arm on purpose: adding a new
+    /// `BackendError` variant fails to compile until it is deliberately
+    /// classified here.
+    #[must_use]
+    pub fn retriability(&self) -> Retriability {
+        match self {
+            // Environmental: the world wasn't ready, the work didn't happen.
+            // The operator can fix the precondition (log in, enter a PIN,
+            // insert the right token, initialize the device) and retry.
+            BackendError::AuthRequired
+            | BackendError::PinRequired
+            | BackendError::PinFailed(_)
+            | BackendError::ManagementKeyRequired
+            | BackendError::UserPinNotInitialized
+            | BackendError::KeyNotFound(_)
+            | BackendError::ObjectNotFound(_)
+            | BackendError::SlotEmpty(_)
+            | BackendError::TokenNotPresent
+            | BackendError::HardwareFailure(_)
+            | BackendError::Configuration(_) => Retriability::Transient,
+
+            // Fatal: re-execution is meaningless or unsafe. A terminal device
+            // state (PIN budget exhausted, capacity full), a definition that
+            // asks for something the backend cannot do, or malformed/unknown
+            // input that retrying cannot resolve.
+            BackendError::PinBlocked
+            | BackendError::CapacityExceeded
+            | BackendError::OperationNotPermitted(_)
+            | BackendError::AttributeReadOnly(_)
+            | BackendError::UnsupportedAlgorithm(_)
+            | BackendError::UnsupportedOperation(_)
+            | BackendError::InvalidKeyFormat(_)
+            | BackendError::InvalidData(_)
+            | BackendError::NotFound(_)
+            | BackendError::Other(_) => Retriability::Fatal,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retriability_is_retriable_predicate() {
+        assert!(Retriability::Transient.is_retriable());
+        assert!(!Retriability::Fatal.is_retriable());
+    }
+
+    #[test]
+    fn environmental_errors_are_transient() {
+        let transient = [
+            BackendError::AuthRequired,
+            BackendError::PinRequired,
+            BackendError::PinFailed(2),
+            BackendError::ManagementKeyRequired,
+            BackendError::UserPinNotInitialized,
+            BackendError::KeyNotFound("k".into()),
+            BackendError::ObjectNotFound("o".into()),
+            BackendError::SlotEmpty("9a".into()),
+            BackendError::TokenNotPresent,
+            BackendError::HardwareFailure("cable".into()),
+            BackendError::Configuration("missing".into()),
+        ];
+        for err in transient {
+            assert_eq!(
+                err.retriability(),
+                Retriability::Transient,
+                "expected transient: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn fatal_errors_are_not_retriable() {
+        let fatal = [
+            BackendError::PinBlocked,
+            BackendError::CapacityExceeded,
+            BackendError::OperationNotPermitted("usage".into()),
+            BackendError::AttributeReadOnly("attr".into()),
+            BackendError::UnsupportedAlgorithm("rsa1".into()),
+            BackendError::UnsupportedOperation("wrap".into()),
+            BackendError::InvalidKeyFormat("pem".into()),
+            BackendError::InvalidData("bytes".into()),
+            BackendError::NotFound("backend".into()),
+            BackendError::Other("boom".into()),
+        ];
+        for err in fatal {
+            assert_eq!(
+                err.retriability(),
+                Retriability::Fatal,
+                "expected fatal: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn pin_failed_retriable_but_pin_blocked_terminal() {
+        // The hardware budget: a wrong PIN can be retried; an exhausted one cannot.
+        assert!(BackendError::PinFailed(1).retriability().is_retriable());
+        assert!(!BackendError::PinBlocked.retriability().is_retriable());
+    }
 }

--- a/crates/rite-sdk/src/lib.rs
+++ b/crates/rite-sdk/src/lib.rs
@@ -29,8 +29,8 @@ mod types;
 
 pub use backend::{
     AttestationBackend, Backend, BackendError, CertStoreBackend, KeyStoreBackend,
-    KeyTransportBackend, PivBackend, Pkcs11AdminBackend, Pkcs11Backend, RandomBackend, SignBackend,
-    TpmBackend, YubikeyBackend,
+    KeyTransportBackend, PivBackend, Pkcs11AdminBackend, Pkcs11Backend, RandomBackend,
+    Retriability, SignBackend, TpmBackend, YubikeyBackend,
 };
 
 pub use types::{

--- a/crates/rite-stdlib/src/crypto/export_public.rs
+++ b/crates/rite-stdlib/src/crypto/export_public.rs
@@ -62,9 +62,7 @@ impl Action for ExportPublicAction {
                     "Backend '{backend_name}' does not support key export"
                 ))
             })?;
-            keystore
-                .export_public_key(key_id)
-                .map_err(|e| ActionError::Failed(format!("Failed to export public key: {e}")))?
+            keystore.export_public_key(key_id)?
         };
 
         let fingerprint = compute_fingerprint(&public_key_bytes);

--- a/crates/rite-stdlib/src/crypto/generate_keypair.rs
+++ b/crates/rite-stdlib/src/crypto/generate_keypair.rs
@@ -64,9 +64,7 @@ impl Action for GenerateKeypairAction {
             policy: KeyPolicy::default(),
             location_hint: typed.slot.clone(),
         };
-        let metadata = keystore
-            .generate_key(spec)
-            .map_err(|e| ActionError::Failed(format!("Backend key generation failed: {e}")))?;
+        let metadata = keystore.generate_key(spec)?;
 
         let public_key_fingerprint = metadata.public_key.as_deref().map(compute_fingerprint);
 

--- a/crates/rite-stdlib/src/crypto/unwrap_key.rs
+++ b/crates/rite-stdlib/src/crypto/unwrap_key.rs
@@ -111,9 +111,7 @@ impl Action for UnwrapKeyAction {
             data: wrapped_data,
             recipient_hint: None,
         };
-        let key_metadata = unwrap_backend
-            .unwrap(&wrapped, unwrapping_key_keyid, &label)
-            .map_err(|e| ActionError::Failed(format!("Backend key unwrapping failed: {e}")))?;
+        let key_metadata = unwrap_backend.unwrap(&wrapped, unwrapping_key_keyid, &label)?;
 
         reporter.fact(StepFact::BackendOperation {
             step: step.id.clone(),

--- a/crates/rite-stdlib/src/crypto/wrap_key.rs
+++ b/crates/rite-stdlib/src/crypto/wrap_key.rs
@@ -77,9 +77,7 @@ impl Action for WrapKeyAction {
             }
             let (transport, backend_fp) = require_transport_backend(backend, key_backend)?;
             reporter.log(Icon::Spinner, "Wrapping key using backend...")?;
-            let wk = transport
-                .wrap(key_id, wrap_key_id, wrap_alg)
-                .map_err(|e| ActionError::Failed(format!("Backend key wrapping failed: {e}")))?;
+            let wk = transport.wrap(key_id, wrap_key_id, wrap_alg)?;
             (wk, backend_fp)
         } else {
             let pub_key_bytes = resolve_artifact_bytes(
@@ -98,9 +96,7 @@ impl Action for WrapKeyAction {
                 Icon::Spinner,
                 "Wrapping key to external recipient public key...",
             )?;
-            let wk = transport
-                .wrap_to_public(key_id, &pub_key_bytes, wrap_alg)
-                .map_err(|e| ActionError::Failed(format!("Key wrapping failed: {e}")))?;
+            let wk = transport.wrap_to_public(key_id, &pub_key_bytes, wrap_alg)?;
             (wk, backend_fp)
         };
 

--- a/crates/rite-stdlib/src/pki/generate_csr.rs
+++ b/crates/rite-stdlib/src/pki/generate_csr.rs
@@ -135,9 +135,7 @@ impl Action for GenerateCsrAction {
             ActionError::Failed(format!("Backend '{backend_name}' does not support signing"))
         })?;
 
-        let signature_bytes = sign_backend
-            .sign(&key_id, &info_der, sign_algorithm)
-            .map_err(|e| ActionError::Failed(format!("Signing failed: {e}")))?;
+        let signature_bytes = sign_backend.sign(&key_id, &info_der, sign_algorithm)?;
 
         let csr = CertReq {
             info,

--- a/crates/rite-stdlib/src/pki/issue_certificate.rs
+++ b/crates/rite-stdlib/src/pki/issue_certificate.rs
@@ -236,9 +236,7 @@ impl Action for IssueCertificateAction {
             ActionError::Failed(format!("Backend '{backend_name}' does not support signing"))
         })?;
 
-        let signature_bytes = sign_backend
-            .sign(&key_id, &tbs_der, sign_algorithm)
-            .map_err(|e| ActionError::Failed(format!("Signing failed: {e}")))?;
+        let signature_bytes = sign_backend.sign(&key_id, &tbs_der, sign_algorithm)?;
 
         let cert = Certificate {
             tbs_certificate: tbs,

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,0 +1,71 @@
+# Error Handling
+
+Scope: what happens when a step fails during `rite run`, and the `retry:` field.
+
+## When a step fails
+
+A failure is classified by its nature:
+
+- **Transient**: the world was not ready (a token absent, a loose cable, a PIN
+  required). The run pauses and prompts the operator to **Retry** or **Abort**.
+- **Fatal**: a verification mismatch, a broken definition, or a blocked device.
+  The run stops. There is no retry, because re-running a failed verification
+  would be tampering, not recovery.
+
+Every failed attempt is recorded in the transcript as a `step_attempt_failed`
+event, so a retry is auditable: attempt 1 failed, the operator chose retry,
+attempt 2 succeeded.
+
+A step is **never retried once it has produced evidence** (an artifact, a backend
+operation, or a drawn random value). After a side effect, re-running is not safe,
+so the failure becomes fatal even if its cause was transient.
+
+## Retriability is a property of the failure, not the step
+
+The same action can fail either way depending on what goes wrong, so a step is
+not statically "retryable" or "not retryable":
+
+- Steps that touch hardware or the environment (a token, a TPM, a PIN) can hit
+  transient failures, and so can prompt for retry.
+- Pure-logic and software steps (a `confirm`, a `check_value`, a software-key
+  operation) generally fail fatally: their failures are results, not conditions,
+  so they are never retried.
+
+You do not need to predict this when authoring. The safe default (prompt on a
+transient failure) already applies to every step. The `retry:` field only
+**constrains** that default, it never enables retry:
+
+- `retry: never` always takes effect: it forbids the prompt on any step.
+- `retry: { attempts: N }` only bites if a transient failure actually occurs; on
+  a step that can only fail fatally it is simply inert.
+- A fatal failure ignores `retry:` entirely and stops the run. You cannot retry a
+  verification until it passes; the classification lives on the error types in
+  the runtime, and a ceremony author cannot mark a mismatch retriable.
+
+## Constraining retries: `retry:`
+
+By default a transient failure prompts the operator with no limit. The `retry:`
+field constrains that, per step:
+
+```yaml
+steps:
+  # If the token is absent or a cable is loose, the operator can reseat it and
+  # retry, up to a hard cap. Exhausting the cap fails the ceremony.
+  import_transport_key:
+    action: unwrap_key
+    backend: openssl
+    retry: { attempts: 3 }
+
+  # Forbid retries where repeated attempts are themselves security-relevant
+  # (for example PIN entry against a hardware token).
+  sign_with_token:
+    action: piv_sign
+    backend: yubikey
+    retry: never
+```
+
+Omit `retry:` for the default (prompt, unlimited). `attempts` must be at least 1;
+use `retry: never` to forbid retries entirely.
+
+In non-interactive runs (`rite run --frontend headless`, dry runs) the retry
+prompt resolves to abort, so a deterministic failure does not loop forever.


### PR DESCRIPTION
Introduce an in-run error model so a ceremony can recover from transient failures (a loose cable, an absent token) without losing a long-running session, while ensuring procedural failures are never silently re-run.

Error classification on the types:
- `Retriability` (`Transient` / `Fatal`) with `BackendError::retriability()` and `ActionError::retriability()`, classified by an exhaustive, wildcard-free match so every future variant must be deliberately classified. Environmental conditions are transient; malformed data, unsupported operations, and terminal device states are fatal. A procedural failure such as a verification mismatch is never retriable.

Transcript taxonomy:
- `ErrorClass` (environmental / procedural / integrity / abort) recorded on `ErrorRecord`, so an auditor can tell a failure's nature without parsing the message and abort is distinguishable from failure.
- New `StepAttemptFailed { step, attempt, error }` fact; reports group attempts under their step.

Runtime retry:
- A transient error pauses the step and prompts the operator to retry or abort, recorded through the existing prompt machinery. A conservative re-executability gate refuses to retry once an attempt has emitted any evidence, which also keeps retried attempts from reusing entropy.

DSL `retry:` field:
- `retry: never` and `retry: { attempts: N }` constrain the retry-by-default; an absent field prompts the operator unlimited times. A zero attempt budget is rejected with a resolver diagnostic.