### PR TITLE
docs: add AI-assisted contribution policy and dev setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Agents
+
+This repository may be edited with AI coding assistance, by maintainers and contributors alike,
+under the same standards as any other contribution. See [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+If you are a coding agent working in this repository:
+
+- Read `CONTRIBUTING.md` before proposing or making changes.
+- Follow the conventions in `docs/development/`.
+- Run the local checks from `CONTRIBUTING.md` (`cargo fmt`, `cargo clippy`, `cargo test`) before considering a change complete.
+- A human must read, understand, and review any change before it is submitted.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,26 @@ CLI behavior conventions are documented in `docs/development/cli-conventions.md`
 Runtime and frontend architecture is documented in `docs/development/runtime-and-frontend.md`,
 crate layout in `docs/development/crate-layout.md`.
 
+## AI-assisted contributions
+
+Contributions assisted by AI tools, including LLMs and coding agents, are not forbidden and are
+not held to a different bar than any other contribution. The same rule applies either way: it
+must follow every guideline in this document and in `docs/development/`, and a human must
+carefully read, understand, and stand behind the change before opening an issue or PR.
+
+Mentioning that AI tooling helped in the PR or issue description is welcome, as an additional
+datapoint for any contribution, not as a compliance step.
+
+## Development setup
+
+Requires Rust 1.88+ and `libssl-dev` (OpenSSL headers).
+
+```sh
+cargo build -p rite --features openssl-vendored
+cargo run -p rite -- check examples/showcase/demo.rite.yaml
+cargo run -p rite -- run examples/showcase/demo.rite.yaml
+```
+
 ## Local checks
 
 Run these before pushing.


### PR DESCRIPTION
Clarifies that AI-assisted contributions are welcome under the same guidelines as any other change, with mandatory human review before submission. Adds AGENTS.md for coding agents working in this repo, and a short Development setup section to CONTRIBUTING.md.
