### PR TITLE
fix(transcript): drop brute-forceable secret hash from redacted answers

### DIFF
--- a/crates/rite-model/src/transcript.rs
+++ b/crates/rite-model/src/transcript.rs
@@ -91,12 +91,15 @@ pub enum ResponseRecord {
         /// The answer.
         value: String,
     },
-    /// Secret answer, replaced by a deterministic hash of the plaintext so
-    /// verifiers can confirm a specific secret was provided without seeing it.
-    SecretRedacted {
-        /// Lowercase hex of `sha256(plaintext)`.
-        sha256_of_plaintext: String,
-    },
+    /// Secret answer. The plaintext is never stored, and no digest of it is
+    /// kept either: a hash of a low-entropy secret (such as a 6-8 digit PIV
+    /// PIN) is brute-forceable from a shared transcript. The position of the
+    /// enclosing `PromptAnswered` fact in the chain already records that a
+    /// secret was entered at this point.
+    // Note: a salted, per-run HMAC could later attest that two prompts received
+    // the same secret without reintroducing the low-entropy guessing oracle.
+    // Deferred until a concrete use case needs it.
+    SecretRedacted {},
     /// Acknowledgement of a [`Prompt::Continue`].
     Acknowledged,
 }
@@ -541,18 +544,13 @@ mod schema_snapshot_tests {
                 prompt: Prompt::Secret {
                     label: "PIN".to_string(),
                 },
-                response: ResponseRecord::SecretRedacted {
-                    sha256_of_plaintext: "f".repeat(64),
-                },
+                response: ResponseRecord::SecretRedacted {},
             },
             &json!({
                 "type": "prompt_answered",
                 "step": "s1",
                 "prompt": { "type": "secret", "label": "PIN" },
-                "response": {
-                    "type": "secret_redacted",
-                    "sha256_of_plaintext": "f".repeat(64),
-                },
+                "response": { "type": "secret_redacted" },
             }),
         );
     }

--- a/crates/rite-runtime/src/reporter.rs
+++ b/crates/rite-runtime/src/reporter.rs
@@ -27,13 +27,11 @@ use std::sync::Arc;
 
 use crossbeam_channel::{Receiver, Sender, TryRecvError};
 use rite_model::{ErrorClass, ErrorRecord, Prompt, ResponseRecord, StepFact, StepId};
-use secrecy::ExposeSecret;
 use thiserror::Error;
 
 use crate::clock::Clock;
 use crate::entropy::CeremonyRandom;
 use crate::protocol::{ExecEvent, Icon, PromptId, Response, UiCommand, UiSignal};
-use crate::transcript::sha256_hex;
 use crate::transcript_sink::TranscriptSink;
 
 /// Errors that can arise while emitting events or awaiting a response.
@@ -453,16 +451,14 @@ impl<'a> Reporter<'a> {
 
 /// Convert an in-flight [`Response`] into its redacted, serializable form.
 ///
-/// The boundary where plaintext secrets become a deterministic hash. Lives
-/// here (next to `Response`) rather than on `ResponseRecord` so that
-/// `secrecy` stays a runtime-only dependency.
+/// The boundary where a plaintext secret is dropped. Lives here (next to
+/// `Response`) rather than on `ResponseRecord` so that `secrecy` stays a
+/// runtime-only dependency.
 fn response_to_record(response: &Response) -> ResponseRecord {
     match response {
         Response::Bool(b) => ResponseRecord::Bool { value: *b },
         Response::Text(t) => ResponseRecord::Text { value: t.clone() },
-        Response::Secret(s) => ResponseRecord::SecretRedacted {
-            sha256_of_plaintext: sha256_hex(s.expose_secret().as_bytes()),
-        },
+        Response::Secret(_) => ResponseRecord::SecretRedacted {},
         Response::Acknowledge => ResponseRecord::Acknowledged,
     }
 }
@@ -770,12 +766,7 @@ mod tests {
 
         match sink.facts().first().expect("fact") {
             StepFact::PromptAnswered { response, .. } => match response {
-                ResponseRecord::SecretRedacted {
-                    sha256_of_plaintext,
-                } => {
-                    assert!(!sha256_of_plaintext.contains("hunter"));
-                    assert_eq!(sha256_of_plaintext.len(), 64);
-                }
+                ResponseRecord::SecretRedacted {} => {}
                 other => panic!("expected redacted secret, got {other:?}"),
             },
             other => panic!("unexpected fact: {other:?}"),


### PR DESCRIPTION
Secret prompt answers recorded an unsalted sha256 of the plaintext. A PIV PIN is 6-8 digits, so any holder of the shared transcript recovers it offline in seconds. The digest served no verification purpose: the chain position of the prompt_answered fact already binds that a secret was entered. Record only { "type": "secret_redacted" }.

Closes #126